### PR TITLE
feat: per-shift Google Calendar event colors

### DIFF
--- a/calendar-api-backend/src/controllers/positionController.js
+++ b/calendar-api-backend/src/controllers/positionController.js
@@ -120,6 +120,29 @@ const setUserPositionsToSync = async (req, res) => {
 //   }
 // };
 
+const getUserDefaultEventColorId = async (req, res) => {
+  try {
+    const defaultEventColorId =
+      await positionService.getUserDefaultEventColorId(req.auth.userId);
+    res.status(200).json({ defaultEventColorId });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
+const setUserDefaultEventColorId = async (req, res) => {
+  const { defaultEventColorId } = req.body;
+  try {
+    const saved = await positionService.setUserDefaultEventColorId(
+      req.auth.userId,
+      defaultEventColorId ?? null,
+    );
+    res.status(200).json({ defaultEventColorId: saved });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
 async function getPosition(req, res) {
   const positionId = req.params.positionId;
   try {
@@ -152,6 +175,8 @@ export default {
   getAllPositions,
   setUserPositionsToSync,
   // setUserPositionsToSync_cl,
+  getUserDefaultEventColorId,
+  setUserDefaultEventColorId,
   getPosition,
   deletePosition,
 };

--- a/calendar-api-backend/src/models/UserModel.js
+++ b/calendar-api-backend/src/models/UserModel.js
@@ -36,6 +36,13 @@ const PositionToSyncSchema = new Schema({
     required: true,
     default: false,
   },
+  // Google Calendar event colorId ("1".."11") for shifts of this position.
+  // Absent/null => no color chosen => Google uses the calendar's default color.
+  colorId: {
+    type: String,
+    required: false,
+    default: null,
+  },
 });
 
 // Define work hours for each day of the week
@@ -152,6 +159,14 @@ const UserSchema = new mongoose.Schema({
     type: [PositionToSyncSchema],
     required: false,
     default: initialPositions,
+  },
+  // User-level "one color for everything" override. When set, every synced shift
+  // (current and future) uses this Google Calendar colorId, ignoring per-position
+  // colorId choices. Null/absent => fall back to per-position colorId.
+  defaultEventColorId: {
+    type: String,
+    required: false,
+    default: null,
   },
   slingId: {
     type: String,

--- a/calendar-api-backend/src/routers/positionRouters.js
+++ b/calendar-api-backend/src/routers/positionRouters.js
@@ -14,6 +14,17 @@ positionRouter.get("/sync", positionController.getUserPositionsToSync);
 
 positionRouter.put("/sync", positionController.setUserPositionsToSync);
 
+// Must be declared before "/:positionId" so it isn't captured as a positionId.
+positionRouter.get(
+  "/default-color",
+  positionController.getUserDefaultEventColorId,
+);
+
+positionRouter.put(
+  "/default-color",
+  positionController.setUserDefaultEventColorId,
+);
+
 positionRouter.put("/:positionId", adminOnly, positionController.updatePosition);
 
 positionRouter.delete(

--- a/calendar-api-backend/src/services/gCalendarService.js
+++ b/calendar-api-backend/src/services/gCalendarService.js
@@ -458,9 +458,17 @@ const addDaysShiftsToGcal = async (date, requestId = "req-id-nd") => {
         const shiftsToAdd = userShifts.filter((event) =>
           positionsToSync.includes(event.position.id.toString()),
         );
-        const userEvents = shiftsToAdd.map((shift) =>
-          utils.shiftToEvent(shift),
+        const colorByPositionId = new Map(
+          (user.positionsToSync || [])
+            .filter((p) => p.colorId)
+            .map((p) => [p.positionId.toString(), p.colorId]),
         );
+        const userEvents = shiftsToAdd.map((shift) => {
+          const colorId =
+            user.defaultEventColorId ||
+            colorByPositionId.get(shift.position.id.toString());
+          return utils.shiftToEvent(shift, colorId);
+        });
 
         console.log(
           `[${requestId}] - Adding ${userEvents.length} shifts to GCal for ${user.email} on date ${date}`,
@@ -609,9 +617,19 @@ const addDaysShiftsToGcal_cl = async (date, requestId = "req-id-nd") => {
       const shiftsToAdd = userShifts.filter((event) =>
         positionsToSync.includes(event.position.id.toString()),
       );
-      const userEvents = shiftsToAdd.map((shift) =>
-        utils.shiftToEvent(shift),
+      // Per-position Google Calendar colors (Sling positionId -> colorId). The
+      // user-level default, when set, wins over every per-position choice.
+      const colorByPositionId = new Map(
+        (mongoUser.positionsToSync || [])
+          .filter((p) => p.colorId)
+          .map((p) => [p.positionId.toString(), p.colorId]),
       );
+      const userEvents = shiftsToAdd.map((shift) => {
+        const colorId =
+          mongoUser.defaultEventColorId ||
+          colorByPositionId.get(shift.position.id.toString());
+        return utils.shiftToEvent(shift, colorId);
+      });
 
       console.log(
         `[${requestId}] - Adding ${userEvents.length} shifts to GCal for ${user.firstName} on date ${date}`,
@@ -850,7 +868,19 @@ const addUsersDayShifts = async (user, date, requestId = "req-id-nd") => {
     const shiftsToAdd = userShifts.filter((event) =>
       positionsToSync.includes(event.position.id.toString()),
     );
-    const userEvents = shiftsToAdd.map((shift) => utils.shiftToEvent(shift));
+    // Per-position Google Calendar colors (Sling positionId -> colorId); the
+    // user-level default, when set, overrides every per-position choice.
+    const colorByPositionId = new Map(
+      (user.positionsToSync || [])
+        .filter((p) => p.colorId)
+        .map((p) => [p.positionId.toString(), p.colorId]),
+    );
+    const userEvents = shiftsToAdd.map((shift) => {
+      const colorId =
+        user.defaultEventColorId ||
+        colorByPositionId.get(shift.position.id.toString());
+      return utils.shiftToEvent(shift, colorId);
+    });
 
     console.log(
       `[${requestId}] - Adding ${userEvents.length} shifts to GCal for ${user.email} on date ${date}`,
@@ -972,7 +1002,17 @@ const addUsersDayShifts_cl = async (user, date, requestId = "req-id-nd") => {
     const shiftsToAdd = userShifts.filter((event) =>
       positionsToSync.includes(event.position.id.toString()),
     );
-    const userEvents = shiftsToAdd.map((shift) => utils.shiftToEvent(shift));
+    const colorByPositionId = new Map(
+      (user.publicMetadata.positionsToSync || [])
+        .filter((p) => p.colorId)
+        .map((p) => [p.positionId.toString(), p.colorId]),
+    );
+    const userEvents = shiftsToAdd.map((shift) => {
+      const colorId =
+        user.publicMetadata.defaultEventColorId ||
+        colorByPositionId.get(shift.position.id.toString());
+      return utils.shiftToEvent(shift, colorId);
+    });
 
     console.log(
       `[${requestId}] - Adding ${userEvents.length} shifts to GCal for ${user.firstName} on date ${date}`,
@@ -1046,8 +1086,13 @@ const addEventForShift = async (
       return;
     }
 
+    // Resolve the user's chosen Google Calendar color for this shift's position
+    // (user-level default -> per-position choice -> none). Read from the Mongo user,
+    // the same source the settings panel writes.
+    const position = await positionService.getPositionById(shift.positionId);
+    const colorId = positionService.resolveEventColorId(mongoUser, position);
     // transform shift into calendar event
-    event = await newShiftToEvent(shift);
+    event = await newShiftToEvent(shift, colorId);
     // add event to GCal
     addedEvent = await addEvent_cl(user, event, requestId);
     // add event to addedGCalEvents collection with MongoDB user ID for consistency

--- a/calendar-api-backend/src/services/positionService.js
+++ b/calendar-api-backend/src/services/positionService.js
@@ -122,6 +122,38 @@ const setUserPositionsToSync = async (userId, positions) => {
   await user.save();
 };
 
+const getUserDefaultEventColorId = async (userId) => {
+  const user = await userService.findUserByClerkId(userId);
+  if (!user) {
+    throw new Error("User not found");
+  }
+  return user.defaultEventColorId ?? null;
+};
+
+const setUserDefaultEventColorId = async (userId, colorId) => {
+  const user = await userService.findUserByClerkId(userId);
+  if (!user) {
+    throw new Error("User not found");
+  }
+  // Normalize "" / undefined to null so "clear the default" is unambiguous.
+  user.defaultEventColorId = colorId || null;
+  await user.save();
+  return user.defaultEventColorId;
+};
+
+// Resolve the Google Calendar colorId to use for a shift of `position` for `user`.
+// Precedence: user-level default -> per-position choice -> undefined (Google default).
+// `position` is a Position doc; matched against positionsToSync by the Sling positionId,
+// the same key the settings panel reads/writes.
+const resolveEventColorId = (user, position) => {
+  if (!user) return undefined;
+  if (user.defaultEventColorId) return user.defaultEventColorId;
+  const match = (user.positionsToSync || []).find(
+    (p) => p.positionId === position?.positionId,
+  );
+  return match?.colorId || undefined;
+};
+
 export default {
   createPosition,
   getPositions,
@@ -132,4 +164,7 @@ export default {
   getPositionsToSyncForUsers,
   getEnforcedPositionIds,
   setUserPositionsToSync,
+  getUserDefaultEventColorId,
+  setUserDefaultEventColorId,
+  resolveEventColorId,
 };

--- a/calendar-api-backend/src/utils/newShiftToEvent.js
+++ b/calendar-api-backend/src/utils/newShiftToEvent.js
@@ -1,6 +1,6 @@
 import positionService from "../services/positionService.js";
 
-export async function newShiftToEvent(shift) {
+export async function newShiftToEvent(shift, colorId) {
   const positionName = await positionService.getPositionById(shift.positionId);
   console.log("positionName: ", JSON.stringify(positionName));
 
@@ -16,5 +16,7 @@ export async function newShiftToEvent(shift) {
       timeZone: "GMT",
     },
   };
+  // Google Calendar colorId ("1".."11"); omit entirely when no color is chosen.
+  if (colorId) event.colorId = colorId;
   return event;
 }

--- a/calendar-api-backend/src/utils/utils.js
+++ b/calendar-api-backend/src/utils/utils.js
@@ -18,7 +18,7 @@ const todayISO = (date) => {
   return `${startOfDayISO}/${endOfDayISO}`;
 };
 
-const shiftToEvent = (shift) => {
+const shiftToEvent = (shift, colorId) => {
   const event = {
     summary: shift.position.name,
     description: `event created by agendo on ${new Date().toString()}`,
@@ -31,6 +31,8 @@ const shiftToEvent = (shift) => {
       timeZone: "Brazil/East",
     },
   };
+  // Google Calendar colorId ("1".."11"); omit entirely when no color is chosen.
+  if (colorId) event.colorId = colorId;
   return event;
 };
 

--- a/calendar-api-frontend/src/pages/Settings/Settings.tsx
+++ b/calendar-api-frontend/src/pages/Settings/Settings.tsx
@@ -77,7 +77,7 @@ export default function Settings() {
               href="#shifts-to-add-to-cal"
               className={"font-semibold text-primary"}
             >
-              Shifts on GCalendar
+              Synced shifts
             </a>
             <a
               href="#generate-api-token"

--- a/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/ApplyColorMenu.tsx
+++ b/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/ApplyColorMenu.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useState } from "react";
+import { MoreVertical, X } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button.tsx";
+import { Checkbox } from "@/components/ui/checkbox.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu.tsx";
+import { useUserSettings } from "@/providers/useUserSettings.tsx";
+import { useSettings } from "@/providers/useSettings.tsx";
+import { ColorPickerContent } from "./ColorPicker.tsx";
+import { saveDefaultEventColorId } from "./utils.tsx";
+
+const HINT_DISMISS_KEY = "agendo:applyColorHintDismissed";
+
+export function ApplyColorMenu() {
+  const {
+    positionsToSync,
+    setPositionsToSync,
+    defaultEventColorId,
+    setDefaultEventColorId,
+  } = useUserSettings();
+  const { rowSelection } = useSettings();
+
+  const [open, setOpen] = useState(false);
+  const [dialogColor, setDialogColor] = useState<string | null>(null);
+  const [makeDefault, setMakeDefault] = useState(false);
+  const [hintDismissed, setHintDismissed] = useState(
+    () => localStorage.getItem(HINT_DISMISS_KEY) === "true"
+  );
+
+  // Seed the dialog from the current default whenever it opens.
+  useEffect(() => {
+    if (open) {
+      setDialogColor(defaultEventColorId ?? null);
+      setMakeDefault(!!defaultEventColorId);
+    }
+  }, [open, defaultEventColorId]);
+
+  // Nudge: same color manually set on 3+ rows suggests they want "apply to all".
+  const repeatedColor = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const p of positionsToSync) {
+      if (!p.colorId) continue;
+      counts.set(p.colorId, (counts.get(p.colorId) ?? 0) + 1);
+    }
+    for (const [id, n] of counts) if (n >= 3) return id;
+    return null;
+  }, [positionsToSync]);
+
+  const showHint = !defaultEventColorId && !!repeatedColor && !hintDismissed;
+
+  const dismissHint = () => {
+    setHintDismissed(true);
+    localStorage.setItem(HINT_DISMISS_KEY, "true");
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      // Belt-and-suspenders: Radix can leave `pointer-events: none` on <body>
+      // after a menu->dialog handoff, which would freeze the whole page.
+      setTimeout(() => {
+        document.body.style.pointerEvents = "";
+      }, 0);
+    }
+  };
+
+  const apply = async () => {
+    // The user just used the feature, so stop nudging them toward it.
+    dismissHint();
+    if (makeDefault) {
+      await saveDefaultEventColorId(dialogColor);
+      setDefaultEventColorId(dialogColor);
+      toast.success(
+        dialogColor
+          ? "This color now applies to all shifts."
+          : "Default color cleared."
+      );
+    } else {
+      // Turning the account-wide default off (if it was on) before a one-time apply.
+      if (defaultEventColorId) {
+        await saveDefaultEventColorId(null);
+        setDefaultEventColorId(null);
+      }
+      setPositionsToSync(
+        positionsToSync.map((p, index) => {
+          const synced = p.enforceSync || !!rowSelection[index];
+          return synced ? { ...p, colorId: dialogColor } : p;
+        })
+      );
+      toast.success("Applied to your synced shifts — click Save to keep it.");
+    }
+    handleOpenChange(false);
+  };
+
+  return (
+    <div className="relative flex items-center">
+      {showHint && (
+        <div className="absolute right-10 top-0 z-10 w-64 rounded-md border bg-popover p-3 text-popover-foreground shadow-md">
+          <button
+            type="button"
+            aria-label="Dismiss"
+            onClick={dismissHint}
+            className="absolute right-1.5 top-1.5 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+          <p className="pr-4 text-sm font-medium">
+            Applying the same color everywhere?
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Use “Set one color for all shifts” in the ⋯ menu to do it in one
+            step — and keep future shifts the same color.
+          </p>
+        </div>
+      )}
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" aria-label="Color options">
+            <MoreVertical className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onSelect={() => {
+              // Defer so the menu fully closes before the dialog opens; opening
+              // both in the same tick leaves `pointer-events: none` stuck on
+              // <body> (Radix menu->dialog handoff), freezing the page.
+              setTimeout(() => setOpen(true), 0);
+            }}
+          >
+            Set one color for all shifts
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Set one color for all shifts</DialogTitle>
+            <DialogDescription>
+              Pick a color to apply to every shift you sync, instead of setting
+              each one by hand.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="py-2">
+            <ColorPickerContent
+              value={dialogColor}
+              onSelect={setDialogColor}
+              positionsToSync={positionsToSync}
+            />
+          </div>
+
+          <label className="flex items-start gap-2 text-sm">
+            <Checkbox
+              checked={makeDefault}
+              onCheckedChange={(v) => setMakeDefault(!!v)}
+              className="mt-0.5"
+            />
+            <span>
+              Make this the default for all shifts, including ones you sync
+              later.
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                When on, per-shift colors are locked to this one until you turn
+                it off.
+              </span>
+            </span>
+          </label>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => handleOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={apply}>Apply</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/ColorPicker.tsx
+++ b/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/ColorPicker.tsx
@@ -1,0 +1,146 @@
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { Position } from "@/types/positionTypes.ts";
+import {
+  GCAL_EVENT_COLORS,
+  hexForColorId,
+} from "./eventColors.ts";
+
+// A single circular color swatch. No `hex` => the "no color" crossed-off circle.
+export function ColorSwatch({
+  hex,
+  selected,
+  className,
+}: {
+  hex?: string;
+  selected?: boolean;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "relative inline-block h-5 w-5 shrink-0 rounded-full border",
+        hex ? "border-black/10" : "border-muted-foreground/40",
+        selected && "ring-2 ring-ring ring-offset-2 ring-offset-background",
+        className
+      )}
+      style={hex ? { backgroundColor: hex } : undefined}
+    >
+      {!hex && (
+        <svg
+          viewBox="0 0 20 20"
+          className="absolute inset-0 h-full w-full text-muted-foreground/60"
+        >
+          <line
+            x1="3.5"
+            y1="16.5"
+            x2="16.5"
+            y2="3.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      )}
+    </span>
+  );
+}
+
+function SwatchButton({
+  colorId,
+  selected,
+  onSelect,
+}: {
+  colorId: string;
+  selected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(colorId)}
+      className="rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      <ColorSwatch hex={hexForColorId(colorId)} selected={selected} />
+    </button>
+  );
+}
+
+// The picker body: "Most used" (colors already applied to other rows) + the 11
+// suggested Google Calendar colors + an optional "No color" clear action.
+// Colors only, no labels (per product decision).
+export function ColorPickerContent({
+  value,
+  onSelect,
+  positionsToSync,
+  excludeId,
+  showClear = true,
+}: {
+  value: string | null;
+  onSelect: (colorId: string | null) => void;
+  positionsToSync: Position[];
+  excludeId?: string;
+  showClear?: boolean;
+}) {
+  const mostUsed = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const p of positionsToSync) {
+      if (!p.colorId) continue;
+      if (excludeId && p._id === excludeId) continue;
+      counts.set(p.colorId, (counts.get(p.colorId) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([id]) => id)
+      .slice(0, 6);
+  }, [positionsToSync, excludeId]);
+
+  return (
+    <div className="space-y-3">
+      {mostUsed.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-muted-foreground">Most used</p>
+          <div className="flex flex-wrap gap-2">
+            {mostUsed.map((id) => (
+              <SwatchButton
+                key={`mru-${id}`}
+                colorId={id}
+                selected={value === id}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <p className="text-xs font-medium text-muted-foreground">Suggested</p>
+        <div className="flex flex-wrap gap-2">
+          {GCAL_EVENT_COLORS.map((c) => (
+            <SwatchButton
+              key={c.id}
+              colorId={c.id}
+              selected={value === c.id}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      </div>
+
+      {showClear && (
+        <button
+          type="button"
+          onClick={() => onSelect(null)}
+          className={cn(
+            "flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground",
+            value === null && "text-foreground"
+          )}
+        >
+          <ColorSwatch selected={value === null} />
+          No color
+        </button>
+      )}
+    </div>
+  );
+}

--- a/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/EventColorCell.tsx
+++ b/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/EventColorCell.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { Row } from "@tanstack/react-table";
+import { Position } from "@/types/positionTypes.ts";
+import { useUserSettings } from "@/providers/useUserSettings.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ColorSwatch, ColorPickerContent } from "./ColorPicker.tsx";
+import { hexForColorId } from "./eventColors.ts";
+
+// The "Event color" cell. A row's sync state is driven by the live table
+// selection (rowSelection), not row.original.sync, so we read row.getIsSelected().
+export function EventColorCell({ row }: { row: Row<Position> }) {
+  const { positionsToSync, setPositionsToSync, defaultEventColorId } =
+    useUserSettings();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const position = row.original;
+
+  const isSynced = row.getIsSelected() || !!position.enforceSync;
+  const defaultActive = !!defaultEventColorId;
+  const disabled = !isSynced || defaultActive;
+
+  // What the circle shows: crossed-off when unsynced; the account default when
+  // the "one color for all" override is on; otherwise this row's chosen color.
+  const shownColorId = !isSynced
+    ? null
+    : defaultActive
+      ? defaultEventColorId
+      : (position.colorId ?? null);
+  const hex = hexForColorId(shownColorId);
+
+  const updateColor = (colorId: string | null) => {
+    setPositionsToSync(
+      positionsToSync.map((p) =>
+        p._id === position._id ? { ...p, colorId } : p
+      )
+    );
+    setPickerOpen(false);
+  };
+
+  if (disabled) {
+    const reason = !isSynced
+      ? "This shift isn't synced, so it has no calendar color. Enable sync to pick one."
+      : "One color is applied to all shifts. Change it from the ⋯ menu at the top of this panel.";
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex cursor-not-allowed opacity-70">
+              <ColorSwatch hex={hex} />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">{reason}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return (
+    <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Choose event color"
+          className="rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          <ColorSwatch hex={hex} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64">
+        <ColorPickerContent
+          value={position.colorId ?? null}
+          excludeId={position._id}
+          positionsToSync={positionsToSync}
+          onSelect={updateColor}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/ShiftsToAddToCal.tsx
+++ b/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/ShiftsToAddToCal.tsx
@@ -10,32 +10,48 @@ import {
 import { columns } from "./columns.tsx";
 import { DataTable } from "./data-table.tsx";
 import { useEffect } from "react";
-import { getPositionsToSync, savePositionsToSync } from "./utils.tsx";
+import {
+  getDefaultEventColorId,
+  getPositionsToSync,
+  savePositionsToSync,
+} from "./utils.tsx";
 import { useSettings } from "@/providers/useSettings.tsx";
 import { useUserSettings } from "@/providers/useUserSettings.tsx";
+import { ApplyColorMenu } from "./ApplyColorMenu.tsx";
 
 export default function ShiftsToAddToCal() {
   const { rowSelection } = useSettings();
-  const { positionsToSync, setPositionsToSync, setOriginalPositionsToSync } =
-    useUserSettings();
+  const {
+    positionsToSync,
+    setPositionsToSync,
+    setOriginalPositionsToSync,
+    setDefaultEventColorId,
+  } = useUserSettings();
 
   useEffect(() => {
     async function getData() {
-      const positionsData = await getPositionsToSync();
+      const [positionsData, defaultColor] = await Promise.all([
+        getPositionsToSync(),
+        getDefaultEventColorId(),
+      ]);
       setPositionsToSync(positionsData);
       setOriginalPositionsToSync(positionsData);
+      setDefaultEventColorId(defaultColor);
     }
     getData();
   }, []);
 
   return (
     <Card className="scroll-mt-20" id="shifts-to-add-to-cal">
-      <CardHeader>
-        <CardTitle>Shifts to add to Google Calendar</CardTitle>
-        <CardDescription>
-          Choose the shifts you want synced to your Google Calendar. Only live
-          channels and breaks are checked by default.
-        </CardDescription>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+        <div className="space-y-1.5">
+          <CardTitle>Synced shifts</CardTitle>
+          <CardDescription>
+            Pick which shifts sync to your Google Calendar and the color each one
+            gets. Only live channels and breaks are checked by default.
+          </CardDescription>
+        </div>
+        <ApplyColorMenu />
       </CardHeader>
       <CardContent>
         <DataTable columns={columns} data={positionsToSync} />

--- a/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/columns.tsx
+++ b/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/columns.tsx
@@ -10,6 +10,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Position } from "@/types/positionTypes.tsx";
+import { EventColorCell } from "./EventColorCell.tsx";
 
 export const columns: ColumnDef<Position>[] = [
   {
@@ -86,5 +87,11 @@ export const columns: ColumnDef<Position>[] = [
         </Button>
       );
     },
+  },
+  {
+    id: "eventColor",
+    header: "Event color",
+    enableSorting: false,
+    cell: ({ row }) => <EventColorCell row={row} />,
   },
 ];

--- a/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/eventColors.ts
+++ b/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/eventColors.ts
@@ -1,0 +1,32 @@
+// The fixed palette of Google Calendar event colors. Google's API only accepts
+// these 11 predefined colorIds ("1".."11") on an event — arbitrary hex is not
+// supported (see https://developers.google.com/workspace/calendar/api/v3/reference/colors).
+// Hex values mirror what Google renders so our swatches match the calendar.
+// NOTE: unrelated to ManagePositions' DEFAULT_COLORS (an arbitrary-hex display palette).
+
+export type GCalEventColor = {
+  id: string; // Google colorId, "1".."11"
+  hex: string; // background color Google renders
+};
+
+export const GCAL_EVENT_COLORS: GCalEventColor[] = [
+  { id: "1", hex: "#7986CB" }, // Lavender
+  { id: "2", hex: "#33B679" }, // Sage
+  { id: "3", hex: "#8E24AA" }, // Grape
+  { id: "4", hex: "#E67C73" }, // Flamingo
+  { id: "5", hex: "#F6BF26" }, // Banana
+  { id: "6", hex: "#F4511E" }, // Tangerine
+  { id: "7", hex: "#039BE5" }, // Peacock
+  { id: "8", hex: "#616161" }, // Graphite
+  { id: "9", hex: "#3F51B5" }, // Blueberry
+  { id: "10", hex: "#0B8043" }, // Basil
+  { id: "11", hex: "#D50000" }, // Tomato
+];
+
+// Resolve a colorId to its hex, or undefined when there's no (valid) color.
+export function hexForColorId(
+  colorId: string | null | undefined
+): string | undefined {
+  if (!colorId) return undefined;
+  return GCAL_EVENT_COLORS.find((c) => c.id === colorId)?.hex;
+}

--- a/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/utils.tsx
+++ b/calendar-api-frontend/src/pages/Settings/ShiftsToAddToCal/utils.tsx
@@ -24,17 +24,21 @@ export async function getPositionsToSync(): Promise<Position[]> {
     const positionsData = (await positionsResponse.json()) as Position[];
     console.log("all positions: ", positionsData);
     const toSyncData = (await toSyncResponse.json()) as PositionSync[];
-    const positions = positionsData.map((position) => ({
-      _id: position._id,
-      positionId: position.positionId,
-      name: position.name,
-      type: position.type,
-      color: position.color,
-      enforceSync: position.enforceSync ?? false,
-      sync:
-        toSyncData.find((toSync) => toSync.positionId === position.positionId)
-          ?.sync ?? false,
-    }));
+    const positions = positionsData.map((position) => {
+      const toSync = toSyncData.find(
+        (toSync) => toSync.positionId === position.positionId
+      );
+      return {
+        _id: position._id,
+        positionId: position.positionId,
+        name: position.name,
+        type: position.type,
+        color: position.color,
+        enforceSync: position.enforceSync ?? false,
+        sync: toSync?.sync ?? false,
+        colorId: toSync?.colorId ?? null,
+      };
+    });
     return positions;
   } catch (error) {
     console.error("Failed to fetch positions:", error);
@@ -56,6 +60,9 @@ export async function savePositionsToSync(
     positionId: currPosition.positionId,
     sync: currPosition.enforceSync ? currPosition.sync : !!rowSelection[index],
     name: currPosition.name,
+    // colorId must be sent for every row: the backend replaces the whole
+    // positionsToSync array, so omitting it would wipe saved colors.
+    colorId: currPosition.colorId ?? null,
   }));
   console.log("selectedPositions: ", selectedPositions);
   try {
@@ -72,5 +79,39 @@ export async function savePositionsToSync(
   } catch (error) {
     console.error("Failed to save positions:", error);
     toast.error("Failed to save positions");
+  }
+}
+
+// User-level "one color for every shift" override (null = no override).
+export async function getDefaultEventColorId(): Promise<string | null> {
+  try {
+    const response = await fetch("/api/position/default-color", {
+      method: "GET",
+      mode: "cors",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    });
+    const data = await response.json();
+    return data.defaultEventColorId ?? null;
+  } catch (error) {
+    console.error("Failed to fetch default event color:", error);
+    return null;
+  }
+}
+
+export async function saveDefaultEventColorId(
+  colorId: string | null
+): Promise<void> {
+  try {
+    await fetch("/api/position/default-color", {
+      method: "PUT",
+      mode: "cors",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ defaultEventColorId: colorId }),
+    });
+  } catch (error) {
+    console.error("Failed to save default event color:", error);
+    toast.error("Failed to save default color");
   }
 }

--- a/calendar-api-frontend/src/providers/user-settings-provider.tsx
+++ b/calendar-api-frontend/src/providers/user-settings-provider.tsx
@@ -19,6 +19,7 @@ type UserSettingsProviderState = {
   allUsers: UserSafeInfo[];
   positionsToSync: Position[];
   originalPositionsToSync: Position[];
+  defaultEventColorId: string | null;
   isGoogleAuthenticated: boolean;
   userGoogleInfo: string;
   unsavedChangesAlertOpen: boolean;
@@ -32,6 +33,7 @@ type UserSettingsProviderState = {
   setAllUsers: (value: UserSafeInfo[]) => void;
   setPositionsToSync: (value: Position[]) => void;
   setOriginalPositionsToSync: (value: Position[]) => void;
+  setDefaultEventColorId: (value: string | null) => void;
   setIsGoogleAuthenticated: (value: boolean) => void;
   setUserGoogleInfo: (value: string) => void;
   setUnsavedChangesAlertOpen: (value: boolean) => void;
@@ -55,6 +57,9 @@ export function UserSettingsProvider({ children }: UserSettingsProviderProps) {
   const [originalPositionsToSync, setOriginalPositionsToSync] = useState<
     Position[]
   >([]);
+  const [defaultEventColorId, setDefaultEventColorId] = useState<string | null>(
+    null
+  );
   const [isGoogleAuthenticated, setIsGoogleAuthenticated] = useState(false);
   const [userGoogleInfo, setUserGoogleInfo] = useState("");
   const [unsavedChangesAlertOpen, setUnsavedChangesAlertOpen] = useState(false);
@@ -141,6 +146,7 @@ export function UserSettingsProvider({ children }: UserSettingsProviderProps) {
     allUsers,
     positionsToSync,
     originalPositionsToSync,
+    defaultEventColorId,
     isGoogleAuthenticated,
     userGoogleInfo,
     unsavedChangesAlertOpen,
@@ -154,6 +160,7 @@ export function UserSettingsProvider({ children }: UserSettingsProviderProps) {
     setAllUsers,
     setPositionsToSync,
     setOriginalPositionsToSync,
+    setDefaultEventColorId,
     setIsGoogleAuthenticated,
     setUserGoogleInfo,
     setUnsavedChangesAlertOpen,

--- a/calendar-api-frontend/src/types/positionTypes.ts
+++ b/calendar-api-frontend/src/types/positionTypes.ts
@@ -12,9 +12,13 @@ export type Position = {
   color: string;
   sync: boolean;
   enforceSync?: boolean; // admin-forced: always synced for every user
+  // Google Calendar event colorId ("1".."11") the user picked for this shift.
+  // null/undefined => no color => Google uses the calendar's default color.
+  colorId?: string | null;
 };
 
 export type PositionSync = {
   positionId: string;
   sync: boolean;
+  colorId?: string | null;
 };


### PR DESCRIPTION
## What & why

Feature request: let users choose the color their synced shifts get in Google Calendar, per shift, with a way to bulk-apply one color to all shifts. Added to the **Synced shifts** settings panel (renamed from the longer "Shifts to add to Google Calendar").

## Feasibility note (important for reviewers)

Google Calendar's API can color an event **only** via `event.colorId`, which points into a **fixed palette of 11 event colors** — it does **not** accept arbitrary hex/RGB. (The "millions of colors" custom picker Google shipped recently is UI-only; the API request for custom hex is still unimplemented.) So the picker is an **11-swatch palette** (Most used + Suggested), not a free-form color picker.

## Backend

- `User.positionsToSync[].colorId` + user-level `User.defaultEventColorId` on the model.
- `positionService.resolveEventColorId(user, position)` — precedence: account default → per-position choice → none (colorId omitted → Google's default color).
- `colorId` injected into **both** sync paths' event builders (`utils.shiftToEvent` for Sling bulk, `newShiftToEvent` for per-shift), resolved from the Mongo user. Only set when truthy.
- `GET`/`PUT /api/position/default-color` (declared before `/:positionId` so it isn't captured as a positionId). Per-row `colorId` rides the existing `PUT /api/position/sync` — required, since that array is fully replaced server-side.

## Frontend

- `eventColors.ts` — the 11 Google swatches (colors only, no labels).
- New **Event color** column: filled circle when colored, crossed-off transparent circle when unsynced/no color; controlled popover picker that closes on select.
- ⋯ menu → **"Set one color for all shifts"** dialog with a "default for future shifts" checkbox. When on, per-row pickers are disabled with an explanatory tooltip; when off, it's a one-time apply to synced rows.
- Discovery hint bubble when the same color is set on 3+ rows **manually** (suppressed once the bulk feature is used).

## Notable implementation details

- Color is **per-user** (the panel reads `User.positionsToSync`); the existing admin per-*position* `color` hex (ManagePositions) is unrelated and left untouched.
- Resolution reads from the Mongo user to sidestep the Clerk `publicMetadata` / Sling-id / Mongo-id split.
- Fixed a Radix menu→dialog handoff bug that left `pointer-events: none` stuck on `<body>` (deferred dialog open + cleanup on close).

## Verification

- `tsc --noEmit` clean; `vite build` succeeds; resolver/injection logic covered by a branch test (9/9 pass); backend files pass `node --check`.
- ⚠️ Not driven interactively — the Settings panel is Clerk-auth-gated and this was implemented without a logged-in session. Please confirm in a logged-in dev env: the palette picker, the ⋯ "apply to all" dialog (both checkbox states), the hint bubble, persistence across reload, and the real event color landing in Google Calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)