### PR TITLE
fix: sync paths ignored the per-position sync flag (unchecked positions kept syncing)

### DIFF
--- a/calendar-api-backend/src/services/gCalendarService.js
+++ b/calendar-api-backend/src/services/gCalendarService.js
@@ -1075,25 +1075,34 @@ async function shouldSyncShift(
   console.log(
     `[${requestId}] - Checking if shift should be synced for user ${clerkUser.id}`,
   );
-  console.log(
-    `[${requestId}] - Details of shift being checked: ${JSON.stringify(
-      shift,
-      null,
-      2,
-    )}`,
-  );
+  const shiftPositionId = shift.positionId.toString();
+
   // Admin-enforced positions always sync, overriding the user's preference.
   // Callers in a loop should pass enforcedObjectIds to avoid a query per shift.
   const enforced =
     enforcedObjectIds ??
     (await positionService.getEnforcedPositionIds()).objectIds;
-  const positionsToSync = (clerkUser.publicMetadata.positionsToSync || []).map(
-    (position) => position._id.toString(),
+  if (enforced.includes(shiftPositionId)) {
+    console.log(
+      `[${requestId}] - Position ${shift.positionId} is admin-enforced; syncing`,
+    );
+    return true;
+  }
+
+  // Read the user's real preference from Mongo — the source the settings panel
+  // writes via setUserPositionsToSync. We must NOT read clerkUser.publicMetadata
+  // here: it isn't updated when the user saves, and the previous code synced
+  // every position merely *present* in it, ignoring each entry's `sync` flag —
+  // which caused unchecked positions to keep syncing.
+  // The shift carries the position's Mongo _id; user prefs are keyed by the
+  // Sling positionId, so resolve the Position doc to bridge the two id-spaces
+  // (same match the bulk sync path uses).
+  const mongoUser = await userService.findUserByClerkId(clerkUser.id);
+  const position = await positionService.getPositionById(shift.positionId);
+  const shouldSync = (mongoUser?.positionsToSync || []).some(
+    (pref) => pref.positionId === position?.positionId && pref.sync === true,
   );
-  const shiftPositionId = shift.positionId.toString();
-  const shouldSync =
-    positionsToSync.includes(shiftPositionId) ||
-    enforced.includes(shiftPositionId);
+
   console.log(
     `[${requestId}] - Position ${shift.positionId} sync status: ${shouldSync}`,
   );


### PR DESCRIPTION
## Bug

Positions a user **unchecked and saved** in Settings → Synced shifts kept syncing to Google Calendar (e.g. "Enterprise, VMs, Urgent tickets"). Confirmed on production the stored data is correct — `sync: false`, not enforced, no id collision — so the defect is in the sync code, not the saved preference.

## Root cause

Multiple sync code paths built their "positions to sync" set from `positionsToSync` **without filtering by `sync === true`**, treating every position *present* in the array as syncable.

The path users actually hit is **`addUsersDayShifts`** (`/api/gcalendar/user-day-shifts-to-gcal`, the "Sync My Shifts" button → `SyncMyGCalBtn.tsx`):
```js
...user.positionsToSync.map((p) => p.positionId.toString())   // no .filter(p => p.sync === true)
```
The same defect existed in the per-shift gate `shouldSyncShift` (which additionally read stale Clerk `publicMetadata` instead of Mongo) and in two currently-unwired siblings (`addDaysShiftsToGcal`, `addUsersDayShifts_cl`).

`addDaysShiftsToGcal_cl` (admin "sync everyone") was already correct — it filters via `getPositionsToSyncForUsers`.

## Fix

Every position-selection sync path now requires `sync === true`:
- **`addUsersDayShifts`** — the user-facing over-sync path (primary fix).
- **`shouldSyncShift`** — now reads the user's **Mongo** `positionsToSync` (the settings panel's source of truth, which Clerk `publicMetadata` never reflects), filters by `sync === true`, and resolves the shift's position `_id` → Sling `positionId` to match prefs.
- The two unwired siblings, for consistency.

Admin-enforced positions still always sync.

## Verification

- `node --check` passes; the gate decision logic is covered by a branch test (unchecked → no-sync, checked → sync, enforced → sync, absent → no-sync).
- ⚠️ Recommend a live check on staging/prod after deploy: with a position unchecked + saved, hit "Sync My Shifts" and confirm it no longer appears in Google Calendar. (Requires a real Google-connected account, so it can't be exercised from CI.)

## Note

Independent of the event-colors work in PR #5; based off `main` so it can ship on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)