### PR TITLE
fix: bulk 'Sync My Shifts' still synced unchecked positions

### DIFF
--- a/calendar-api-backend/src/services/gCalendarService.js
+++ b/calendar-api-backend/src/services/gCalendarService.js
@@ -449,9 +449,9 @@ const addDaysShiftsToGcal = async (date, requestId = "req-id-nd") => {
           await positionService.getEnforcedPositionIds();
         const positionsToSync = [
           ...new Set([
-            ...user.positionsToSync.map((position) =>
-              position.positionId.toString(),
-            ),
+            ...user.positionsToSync
+              .filter((position) => position.sync === true)
+              .map((position) => position.positionId.toString()),
             ...enforcedSlingIds,
           ]),
         ];
@@ -859,9 +859,11 @@ const addUsersDayShifts = async (user, date, requestId = "req-id-nd") => {
       await positionService.getEnforcedPositionIds();
     const positionsToSync = [
       ...new Set([
-        ...user.positionsToSync.map((position) =>
-          position.positionId.toString(),
-        ),
+        ...user.positionsToSync
+          // Only positions the user actually checked. Without this filter every
+          // position in positionsToSync synced, so unchecked shifts kept syncing.
+          .filter((position) => position.sync === true)
+          .map((position) => position.positionId.toString()),
         ...enforcedSlingIds,
       ]),
     ];
@@ -993,9 +995,9 @@ const addUsersDayShifts_cl = async (user, date, requestId = "req-id-nd") => {
       await positionService.getEnforcedPositionIds();
     const positionsToSync = [
       ...new Set([
-        ...user.publicMetadata.positionsToSync.map((position) =>
-          position.positionId.toString(),
-        ),
+        ...user.publicMetadata.positionsToSync
+          .filter((position) => position.sync === true)
+          .map((position) => position.positionId.toString()),
         ...enforcedSlingIds,
       ]),
     ];


### PR DESCRIPTION
## Why a second sync fix

PR #6 (merged 2026-07-17) fixed `shouldSyncShift` — the **per-shift** gate. But the path users actually trigger with **"Sync My Shifts"** is `addUsersDayShifts` (`/api/gcalendar/user-day-shifts-to-gcal`), which was never touched. So production still over-syncs: unchecked positions (e.g. "Enterprise, VMs, Urgent tickets") keep landing in Google Calendar.

Confirmed on production the stored preference is correct (`sync: false`, not enforced) — this is purely a code bug.

## Root cause

`addUsersDayShifts` built its sync set without the `sync` filter:
```js
...user.positionsToSync.map((p) => p.positionId.toString())   // no .filter(p => p.sync === true)
```
Same defect in two currently-unwired siblings (`addDaysShiftsToGcal`, `addUsersDayShifts_cl`). `addDaysShiftsToGcal_cl` (admin "sync everyone") was already correct.

## Fix

All three bulk paths now `.filter((position) => position.sync === true)` before mapping to Sling ids. Enforced positions still always sync. (`shouldSyncShift` is already correct in `main` from PR #6.)

## After merge + deploy

Re-run "Sync My Shifts": the bulk path deletes previously-tracked events before re-adding, so stale unchecked events already on the calendar get cleaned up.

## Verification

- `node --check` passes; filter logic covered by a branch test (unchecked→no-sync, checked→sync, enforced→sync).
- ⚠️ Needs a live check post-deploy with a real Google-connected account (can't be exercised from CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)