### PR TITLE
feat(schedule): redesign the agendo day grid and add admin coverage targets

### DIFF
--- a/calendar-api-backend/app.js
+++ b/calendar-api-backend/app.js
@@ -10,6 +10,7 @@ import userRouter from "./src/routers/userRouter.js";
 import gCalendarRouter from "./src/controllers/gCalendarController.js";
 import slingRouter from "./src/routers/slingRouter.js";
 import positionRouter from "./src/routers/positionRouters.js";
+import coverageMeterRouter from "./src/routers/coverageMeterRouter.js";
 import shiftRouter from "./src/routers/shiftRouter.js";
 import locationRouter from "./src/routers/locationRouter.js";
 import skillRouter from "./src/routers/skillRouter.js";
@@ -67,6 +68,8 @@ startJiraBacklogScheduler();
 app.use("/gcalendar", gCalendarRouter);
 app.use("/sling", requireAuth(), slingRouter);
 app.use("/position", requireAuth(), positionRouter);
+// Coverage targets for the schedule page. Admin-only is enforced inside the router.
+app.use("/coverage-meter", requireAuth(), coverageMeterRouter);
 app.use("/user", userRouter);
 app.use("/shift", requireAuth(), shiftRouter);
 app.use("/location", requireAuth(), locationRouter);

--- a/calendar-api-backend/src/controllers/coverageMeterController.js
+++ b/calendar-api-backend/src/controllers/coverageMeterController.js
@@ -1,0 +1,88 @@
+import mongoose from "mongoose";
+import coverageMeterService from "../services/coverageMeterService.js";
+
+const MAX_NAME_LENGTH = 60;
+const MAX_TARGET = 8;
+/** UTC half-hour slots per day — see CoverageMeterModel.js for why it isn't 24. */
+const SLOTS_PER_DAY = 48;
+const HEX_COLOR = /^#[0-9a-f]{6}$/i;
+
+/**
+ * Validate one meter from a replace-all payload. Returns an error string, or null
+ * when the meter is well formed. The target grid is checked exhaustively because a
+ * malformed row would silently break the schedule page's per-slot lookup.
+ */
+const validateMeter = (meter, index) => {
+  const where = `meters[${index}]`;
+
+  if (!meter || typeof meter !== "object") return `${where} must be an object`;
+
+  if (typeof meter.name !== "string" || !meter.name.trim()) {
+    return `${where}.name is required`;
+  }
+  if (meter.name.trim().length > MAX_NAME_LENGTH) {
+    return `${where}.name must be at most ${MAX_NAME_LENGTH} characters`;
+  }
+  if (typeof meter.color !== "string" || !HEX_COLOR.test(meter.color)) {
+    return `${where}.color must be a hex color like #3B82F6`;
+  }
+
+  if (!Array.isArray(meter.positionIds)) {
+    return `${where}.positionIds must be an array`;
+  }
+  const badId = meter.positionIds.find(
+    (id) => !mongoose.isValidObjectId(id),
+  );
+  if (badId !== undefined) {
+    return `${where}.positionIds contains an invalid position id: ${badId}`;
+  }
+
+  if (!Array.isArray(meter.targets) || meter.targets.length !== 7) {
+    return `${where}.targets must have 7 days`;
+  }
+  for (let day = 0; day < 7; day++) {
+    const row = meter.targets[day];
+    if (!Array.isArray(row) || row.length !== SLOTS_PER_DAY) {
+      return `${where}.targets[${day}] must have ${SLOTS_PER_DAY} half-hour slots`;
+    }
+    for (let slot = 0; slot < SLOTS_PER_DAY; slot++) {
+      const value = row[slot];
+      if (!Number.isInteger(value) || value < 0 || value > MAX_TARGET) {
+        return `${where}.targets[${day}][${slot}] must be an integer between 0 and ${MAX_TARGET}`;
+      }
+    }
+  }
+
+  return null;
+};
+
+const getMeters = async (req, res) => {
+  try {
+    const meters = await coverageMeterService.getMeters();
+    res.status(200).json(meters);
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
+const replaceMeters = async (req, res) => {
+  const meters = req.body?.meters;
+
+  if (!Array.isArray(meters)) {
+    return res.status(400).json({ message: "meters must be an array" });
+  }
+
+  for (let i = 0; i < meters.length; i++) {
+    const error = validateMeter(meters[i], i);
+    if (error) return res.status(400).json({ message: error });
+  }
+
+  try {
+    const saved = await coverageMeterService.replaceAll(meters);
+    res.status(200).json(saved);
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+};
+
+export default { getMeters, replaceMeters };

--- a/calendar-api-backend/src/models/CoverageMeterModel.js
+++ b/calendar-api-backend/src/models/CoverageMeterModel.js
@@ -1,0 +1,52 @@
+import mongoose from "mongoose";
+import process from "process";
+
+const { Schema } = mongoose;
+
+/**
+ * A coverage meter: a named, colored group of positions with an hourly headcount
+ * target for every day of the week. The schedule page renders one coverage row per
+ * meter and flags any half hour where the number of scheduled agents falls below
+ * the target. Admin-only, end to end (see coverageMeterRouter.js).
+ *
+ * Two conventions here are load-bearing — read them before touching this file.
+ *
+ * `positionIds` holds Position._id, the same id space as Shift.positionId, so the
+ * coverage count is a direct join. It is NOT the Sling id in Position.positionId /
+ * User.positionsToSync[].positionId. The codebase mixes both spaces (which is why
+ * positionService.getEnforcedPositionIds exists) — this one is Mongo ids.
+ *
+ * `targets[d][s]` is UTC, Sunday-first: `d` matches Date#getUTCDay() (and the existing
+ * User.workHours.dayOfWeek convention), `s` is a half-hour slot 0..47. Nothing local is
+ * ever persisted — agendo is used across timezones, so a target is an absolute weekly
+ * instant, not a wall-clock label. The client converts to and from its own local time
+ * for display (see the frontend's src/utils/coverageTargets.ts).
+ *
+ * Slots are half-hourly, not hourly, even though the admin edits an hourly grid: whole
+ * UTC hours cannot represent a local hour in a half-hour zone (in UTC+05:30, local
+ * 09:00 is UTC 03:30), so an hourly grid silently shifts every target by 30 minutes.
+ * 48 slots also line up with the schedule grid's own half-hour columns.
+ */
+const CoverageMeterSchema = new Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    color: { type: String, required: true },
+    positionIds: [{ type: Schema.Types.ObjectId, ref: "Position" }],
+    // [7][48] — UTC day-of-week (0 = Sunday) × half-hour slot, each value 0..8.
+    targets: { type: [[Number]], required: true },
+    order: { type: Number, default: 0 },
+  },
+  { timestamps: true },
+);
+
+// Mirror agendo's convention: isolated collections in development.
+const isDev = process.env.NODE_ENV === "development";
+const collectionName = isDev ? "dev-coverage-meters" : "coverage-meters";
+
+const CoverageMeter = mongoose.model(
+  "CoverageMeter",
+  CoverageMeterSchema,
+  collectionName,
+);
+
+export default CoverageMeter;

--- a/calendar-api-backend/src/routers/coverageMeterRouter.js
+++ b/calendar-api-backend/src/routers/coverageMeterRouter.js
@@ -1,0 +1,16 @@
+import express from "express";
+import coverageMeterController from "../controllers/coverageMeterController.js";
+import adminOnly from "../middlewares/adminOnly.js";
+
+const coverageMeterRouter = express.Router();
+
+// Admin-only throughout, reads included: coverage targets are a management tool and
+// the schedule page only renders coverage rows for admins, so the data isn't readable
+// by a normal user hitting the API directly. adminOnly is bypassed in development.
+//
+// The whole list is written at once (PUT /) rather than per-item CRUD, because the
+// settings card batches every edit behind a single "Save changes" button.
+coverageMeterRouter.get("/", adminOnly, coverageMeterController.getMeters);
+coverageMeterRouter.put("/", adminOnly, coverageMeterController.replaceMeters);
+
+export default coverageMeterRouter;

--- a/calendar-api-backend/src/services/coverageMeterService.js
+++ b/calendar-api-backend/src/services/coverageMeterService.js
@@ -1,0 +1,44 @@
+import mongoose from "mongoose";
+import CoverageMeter from "../models/CoverageMeterModel.js";
+
+const getMeters = async () => await CoverageMeter.find().sort({ order: 1 });
+
+/**
+ * Replace the whole meter list in one shot.
+ *
+ * The settings card batches every edit behind a single "Save changes" button, so the
+ * client sends the complete list rather than a stream of per-item creates/updates/
+ * deletes. Meters absent from the payload are deleted; the rest are upserted with
+ * `order` set from their position in the array.
+ *
+ * Meters the client created locally arrive without an `_id` (or with a temporary one
+ * that isn't a valid ObjectId) and are inserted.
+ */
+const replaceAll = async (meters) => {
+  const keptIds = meters
+    .map((meter) => meter._id)
+    .filter((id) => id && mongoose.isValidObjectId(id));
+
+  await CoverageMeter.deleteMany({ _id: { $nin: keptIds } });
+
+  await Promise.all(
+    meters.map((meter, index) => {
+      const doc = {
+        name: meter.name,
+        color: meter.color,
+        positionIds: meter.positionIds,
+        targets: meter.targets,
+        order: index,
+      };
+
+      if (meter._id && mongoose.isValidObjectId(meter._id)) {
+        return CoverageMeter.updateOne({ _id: meter._id }, { $set: doc });
+      }
+      return CoverageMeter.create(doc);
+    }),
+  );
+
+  return await getMeters();
+};
+
+export default { getMeters, replaceAll };

--- a/calendar-api-frontend/src/components/ScheduleCalendar/CreateShiftBtn.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/CreateShiftBtn.tsx
@@ -378,13 +378,13 @@ export default function NewShiftForm({ selectedDate }: NewShiftFormProps) {
     <Dialog open={isOpen} onOpenChange={handleOpenChange} modal={false}>
       <DialogTrigger asChild>
         <Button
-          variant="outline"
+          className="h-[34px] gap-[7px] whitespace-nowrap rounded-lg px-3 text-[13px] font-semibold"
           style={{
             display: userType !== "admin" ? "none" : "flex",
             alignItems: "center",
           }}
         >
-          <SquarePen size="16" /> Create New Shift
+          <SquarePen size="15" /> New shift
         </Button>
       </DialogTrigger>
       <DialogContent

--- a/calendar-api-frontend/src/components/ScheduleCalendar/DuplicateShifts.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/DuplicateShifts.tsx
@@ -170,12 +170,13 @@ function DuplicateShifts({ selectedDate }: DuplicateShiftsProps) {
       <DialogTrigger asChild>
         <Button
           variant="outline"
+          className="h-[34px] gap-[7px] whitespace-nowrap rounded-lg px-3 text-[13px]"
           style={{
             display: userType !== "admin" ? "none" : "flex",
             alignItems: "center",
           }}
         >
-          <Copy size="16" /> Duplicate shifts
+          <Copy size="15" /> Duplicate day
         </Button>
       </DialogTrigger>
       <DialogContent

--- a/calendar-api-frontend/src/components/ScheduleCalendar/ScheduleCalendar.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/ScheduleCalendar.tsx
@@ -1,87 +1,23 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
 import AirDatepicker from "air-datepicker";
 import "air-datepicker/air-datepicker.css";
 import localeEn from "air-datepicker/locale/en";
-import { useEffect, useRef, useState } from "react";
-import { Label } from "@radix-ui/react-label";
-import { Input } from "../ui/input.tsx";
-import { CalendarIcon, CalendarSearch, RepeatIcon } from "lucide-react";
-import { Markup } from "interweave";
-import {
-  getShifts,
-  calculateGridColumnSpan,
-  calculateGridColumnStart,
-  getGCalendarEvents,
-  prettyGCalTime,
-  calculateShiftOverlapAmount,
-} from "./scheduleUtils.ts";
-import { CalendarUser, UserGCalGrid } from "@/types/gCalendarTypes.ts";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getShifts, getGCalendarEvents, startOfLocalDay } from "./scheduleUtils.ts";
+import { CalendarUser, GCalEventWithGrid } from "@/types/gCalendarTypes.ts";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "../ui/button.tsx";
 import CalendarHeader from "./calendar-components/CalendarHeader.tsx";
+import ScheduleToolbar from "./calendar-components/ScheduleToolbar.tsx";
+import AgentRow from "./calendar-components/AgentRow.tsx";
+import CoverageRow from "./calendar-components/CoverageRow.tsx";
+import NowLine from "./calendar-components/NowLine.tsx";
+import ScheduleLegend from "./calendar-components/ScheduleLegend.tsx";
 import { useUserSettings } from "@/providers/useUserSettings.tsx";
-import { SortedCalendar } from "@/types/shiftTypes.ts";
-import CreateShiftForm from "./CreateShiftBtn.tsx";
-import { Shift } from "./Shift.tsx";
 import { useUser } from "@clerk/clerk-react";
-import { cn } from "@/lib/utils.ts";
-import EmptySlot from "./calendar-components/EmptySlot.tsx";
-import DuplicateShifts from "./DuplicateShifts.tsx";
 import { useSchedule } from "@/providers/useSchedule.tsx";
-import ToggleBulkSelector from "./calendar-components/ToggleBulkSelector.tsx";
-import { UserSafeInfo } from "@/types/userTypes.ts";
 import { useScheduleDateParam } from "@/hooks/useScheduleDateParam.ts";
-import DateNavButtons from "@/components/DateNavButtons/DateNavButtons.tsx";
 
-const calcUserRowHeight = (
-  userId: string,
-  events: CalendarUser[],
-  shifts: SortedCalendar
-) => {
-  let height = 0;
-  const calendarUser = events.find(
-    (calUser: CalendarUser) => calUser.userId === userId
-  );
-
-  if (calendarUser) {
-    height += calendarUser.numberOfEventOverlaps * 2;
-  }
-
-  const userShifts = shifts[userId];
-  height += calculateShiftOverlapAmount(userShifts) * 3;
-
-  return `${height}rem`;
-};
-
-const calculateGridForGCalEvents = (
-  allUsers: UserSafeInfo[],
-  events: CalendarUser[],
-  selectedDate: Date
-): UserGCalGrid[] => {
-  return allUsers.map(({ id: userId }) => ({
-    userId,
-    events:
-      events
-        .find((calUser) => calUser.userId === userId)
-        ?.events.map((event) => ({
-          ...event,
-          gridStart: calculateGridColumnStart(
-            event.start.dateTime,
-            selectedDate.toString()
-          ),
-          gridSpan: calculateGridColumnSpan(
-            event.start.dateTime,
-            event.end.dateTime,
-            selectedDate.toString()
-          ),
-        })) || [],
-  }));
-};
+/** Row height of a single-lane agent row — the skeleton matches it so nothing jumps. */
+const SKELETON_ROW_HEIGHT = 32;
 
 const Schedule = () => {
   const {
@@ -94,59 +30,50 @@ const Schedule = () => {
   } = useSchedule();
   const { selectedDate, dateKey, setDate } = useScheduleDateParam();
   const datepickerRef = useRef<AirDatepicker | null>(null);
-  const [gCalEventsCalculatedGrid, setGCalEventsCalculatedGrid] = useState<
-    UserGCalGrid[]
-  >([]);
-  const { type, allUsers } = useUserSettings();
+  const { type, allUsers, allPositions, coverageMeters } = useUserSettings();
   const { user } = useUser();
   const visitorId = user?.id;
+
+  const isAdmin = type === "admin";
+  const isToday =
+    startOfLocalDay(selectedDate).getTime() ===
+    startOfLocalDay(new Date()).getTime();
+
+  const [showTargets] = useState(true);
+
+  const positionsById = useMemo(
+    () => new Map(allPositions.map((position) => [String(position._id), position])),
+    [allPositions]
+  );
+
+  /** Google Calendar events keyed by user, ready for the under-lane. */
+  const eventsByUser = useMemo(() => {
+    const byUser = new Map<string, GCalEventWithGrid[]>();
+    events.forEach((calUser: CalendarUser) => {
+      byUser.set(
+        String(calUser.userId),
+        calUser.events as unknown as GCalEventWithGrid[]
+      );
+    });
+    return byUser;
+  }, [events]);
 
   const fetchData = async (date: Date) => {
     setScheduleIsLoading(true);
     try {
       const [shifts, events] = await Promise.all([
         getShifts(date),
-        type === "admin" ? getGCalendarEvents(date) : Promise.resolve([]),
+        isAdmin ? getGCalendarEvents(date) : Promise.resolve([]),
       ]);
 
       setShifts(shifts);
       setEvents(events);
-
-      const allUsersGridCalculated = calculateGridForGCalEvents(
-        allUsers,
-        events,
-        date
-      );
-      setGCalEventsCalculatedGrid(allUsersGridCalculated);
-
-      setScheduleIsLoading(false);
     } catch (error) {
       console.error("Error fetching calendar data:", error);
+    } finally {
       setScheduleIsLoading(false);
     }
   };
-
-  // const memoizedGCalEvents = useMemo(() => {
-  //   const allUsersGridCalculated = allUsers.map(({ id: userId }) => ({
-  //     userId,
-  //     events:
-  //       events
-  //         .find((calUser) => calUser.userId === userId)
-  //         ?.events.map((event) => ({
-  //           ...event,
-  //           gridStart: calculateGridColumnStart(
-  //             event.start.dateTime,
-  //             selectedDate.toString()
-  //           ),
-  //           gridSpan: calculateGridColumnSpan(
-  //             event.start.dateTime,
-  //             event.end.dateTime,
-  //             selectedDate.toString()
-  //           ),
-  //         })) || [],
-  //   }));
-  //   return allUsersGridCalculated;
-  // }, [events, selectedDate]);
 
   const todayButton = {
     content: "Today",
@@ -190,223 +117,75 @@ const Schedule = () => {
 
   return (
     <div>
-      <div id="app" className="flex flex-row gap-5 p-5 pl-2 w-full">
-        <Label htmlFor="date" className="flex relative">
-          <Input
-            id="date"
-            className="hover:bg-secondary/80 cursor-pointer"
-            placeholder="Select a date"
-            value={selectedDate.toDateString()}
-            readOnly
-          />
-          <CalendarSearch className="absolute top-1/2 right-2 transform -translate-y-1/2 h-5 w-5" />
-        </Label>
-        <DateNavButtons selectedDate={selectedDate} onSelectDate={setDate} />
-        <CreateShiftForm selectedDate={selectedDate} />
-        <DuplicateShifts selectedDate={selectedDate} />
-        <ToggleBulkSelector />
-      </div>
-      {!scheduleIsLoading ? (
-        <div id="schedule-wrapper" className="flex flex-col">
-          <CalendarHeader />
-          {/* User rows */}
-          {allUsers
-            ? allUsers.map((currUser, idx) => {
-                const userId = currUser.id;
-                return (
-                  <div key={idx} className="flex">
-                    <div
-                      id="user-info-wrapper"
-                      className={`${cn(
-                        "p-2 flex items-center border-b",
-                        String(userId) === String(visitorId)
-                          ? "bg-secondary/80"
-                          : "background"
-                      )}`}
-                      style={{
-                        width: "12%",
-                        height: calcUserRowHeight(userId, events, shifts),
-                      }}
-                    >
-                      <Avatar>
-                        <AvatarImage
-                          src={currUser.imageUrl}
-                          className="w-7 h-7 rounded-full mr-2"
-                        />
-                        <AvatarFallback className="w-7 h-7 px-2 py-1 rounded-full mr-2 bg-slate-950 text-slate-100 font-semibold">
-                          {`${currUser?.firstName[0]}${currUser?.lastName[0]}`}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div>
-                        <div className="text-xs font-semibold truncate">{`${currUser.firstName} ${currUser.lastName}`}</div>
-                      </div>
-                    </div>
-                    <div
-                      id="shifts-data-column"
-                      className="flex-1 overflow-x-auto"
-                    >
-                      <div id="visual-grid-wrapper" className="relative">
-                        <div
-                          className={cn(
-                            "grid absolute inset-0 grid border-b",
-                            String(userId) === String(visitorId)
-                              ? "bg-secondary/80"
-                              : "background"
-                          )}
-                          style={{
-                            gridTemplateColumns: "repeat(24, minmax(0, 1fr))",
-                            height: calcUserRowHeight(userId, events, shifts),
-                          }}
-                        >
-                          {[...Array(24).keys()].map((value) => {
-                            return (
-                              <EmptySlot
-                                userId={String(userId)}
-                                visitorId={String(visitorId)}
-                                currentHour={value}
-                                selectedDate={selectedDate}
-                                key={`${userId}-${value}`}
-                              />
-                            );
-                          })}
-                        </div>
-                      </div>
-                      <div
-                        id="shifts-wrapper"
-                        className="grid"
-                        style={{
-                          gridTemplateColumns: "repeat(48, minmax(0, 1fr))",
-                        }}
-                      >
-                        {shifts[userId] ? (
-                          shifts[userId].map((shift, idx) => (
-                            <Shift
-                              shift={shift}
-                              key={`${idx}-${shift._id}`}
-                              selectedDate={selectedDate}
-                              reloadScheduleCalendar={() =>
-                                fetchData(selectedDate)
-                              }
-                            />
-                          ))
-                        ) : (
-                          <div
-                            className={`p-1 m-[0.2rem] z-10 overflow-hidden whitespace-nowrap truncate rounded text-white h-10`}
-                          ></div>
-                        )}
-                      </div>
-                      {/* Always render Google Calendar events for all users */}
-                      <div
-                        id="gcalendar-wrapper"
-                        className="grid"
-                        style={{
-                          gridTemplateColumns: "repeat(48, minmax(0, 1fr))",
-                        }}
-                      >
-                        {gCalEventsCalculatedGrid
-                          .find((calUser) => calUser.userId === userId)
-                          ?.events.map((event, idx) => {
-                            return (
-                              <HoverCard key={idx}>
-                                <HoverCardTrigger asChild>
-                                  <div
-                                    key={idx}
-                                    className={`p-1 m-[0.2rem] z-10 overflow-hidden whitespace-nowrap truncate rounded`}
-                                    style={{
-                                      gridColumnStart: event.gridStart,
-                                      gridColumnEnd: `span ${event.gridSpan}`,
-                                      gridRowStart: event?.gridRowNumber,
-                                      backgroundColor: `color-mix(in srgb, white 95%, hsl(var(--shiftmix)) 20%)`,
-                                      fontSize: "0.6875rem",
-                                    }}
-                                  >
-                                    <div className="truncate text-black">
-                                      {event.summary}
-                                    </div>
-                                  </div>
-                                </HoverCardTrigger>
-                                <HoverCardContent className="w-full max-w-md p-6 grid gap-6">
-                                  <div className="flex items-start gap-4">
-                                    <div className="bg-muted rounded-md flex items-center justify-center aspect-square w-12">
-                                      <CalendarIcon className="w-6 h-6" />
-                                    </div>
-                                    <div className="grid gap-1">
-                                      <div className="flex items-center gap-2">
-                                        <h3 className="text-xl font-semibold">
-                                          {event.summary}
-                                        </h3>
-                                        {event.recurringEventId && (
-                                          <RepeatIcon className="w-5 h-5 text-muted-foreground" />
-                                        )}
-                                      </div>
-                                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                        <CalendarIcon className="w-4 h-4" />
-                                        <span>
-                                          {prettyGCalTime(
-                                            event.start.dateTime,
-                                            event.end.dateTime
-                                          )}
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <p className="text-muted-foreground max-h-28 truncate">
-                                    <Markup content={event.description} />
-                                  </p>
-                                  <div className="flex gap-4">
-                                    <Button asChild variant="link">
-                                      <a
-                                        href={event.htmlLink}
-                                        target="_blank"
-                                        rel="noreferrer"
-                                      >
-                                        See more
-                                      </a>
-                                    </Button>
-                                    {event.hangoutLink && (
-                                      <Button>
-                                        <a
-                                          href={event.hangoutLink}
-                                          target="_blank"
-                                          rel="noreferrer"
-                                        >
-                                          Join meeting
-                                        </a>
-                                      </Button>
-                                    )}
-                                  </div>
-                                </HoverCardContent>
-                              </HoverCard>
-                            );
-                          })}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })
-            : null}
-        </div>
-      ) : (
-        <div className="flex-1 flex justify-center">
-          {/* <p>Loading...</p> */}
-          <div className="flex flex-col w-full">
-            <div className="flex flex-col">
-              <Skeleton className="h-10 w-full mb-2" />
+      <ScheduleToolbar
+        selectedDate={selectedDate}
+        onSelectDate={setDate}
+        isToday={isToday}
+      />
+
+      {/* One card, one horizontal scroll container. The 252px agent column is sticky
+          inside it, so the whole grid scrolls together instead of every row owning
+          its own scrollbar. `relative` sits on the inner 1500px track rather than on
+          the scroll container, so NowLine measures the full track and scrolls with
+          it instead of hanging off the viewport. */}
+      <div className="mx-5 mb-6 overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+        <div className="overflow-x-auto">
+          {scheduleIsLoading ? (
+            <div className="p-3">
               {Array.from({
-                length: Math.ceil(window.innerHeight / 80) - 2,
+                length: Math.max(6, allUsers.length || 12),
               }).map((_, idx) => (
-                <div key={idx} className="flex mb-2">
-                  <div className="w-1/6 h-14 mr-2 flex items-center">
-                    <Skeleton className="w-9 h-9 rounded-full" />
-                    <Skeleton className="flex-1 h-7 ml-2" />
-                  </div>
-                  <Skeleton className="flex-1 h-14" />
+                <div
+                  key={idx}
+                  className="mb-1 flex items-center gap-2"
+                  style={{ height: SKELETON_ROW_HEIGHT }}
+                >
+                  <Skeleton className="h-[22px] w-[22px] shrink-0 rounded-full" />
+                  <Skeleton className="h-4 w-[200px] shrink-0" />
+                  <Skeleton className="h-[22px] flex-1" />
                 </div>
               ))}
             </div>
-          </div>
+          ) : (
+            <div className="relative min-w-[1500px]">
+              <CalendarHeader
+                agentCount={allUsers.length}
+                isToday={isToday}
+              />
+
+              {/* Coverage rows are admin-only, on the client and on the API. */}
+              {isAdmin &&
+                coverageMeters.map((meter) => (
+                  <CoverageRow
+                    key={meter._id}
+                    meter={meter}
+                    roster={allUsers}
+                    shifts={shifts}
+                    selectedDate={selectedDate}
+                    showTargets={showTargets}
+                  />
+                ))}
+
+              {allUsers.map((currUser) => (
+                <AgentRow
+                  key={currUser.id}
+                  user={currUser}
+                  shifts={shifts[currUser.id] ?? []}
+                  events={eventsByUser.get(String(currUser.id)) ?? []}
+                  positionsById={positionsById}
+                  selectedDate={selectedDate}
+                  isVisitor={String(currUser.id) === String(visitorId)}
+                  reloadScheduleCalendar={() => fetchData(selectedDate)}
+                />
+              ))}
+
+              <NowLine isToday={isToday} />
+            </div>
+          )}
         </div>
-      )}
+
+        <ScheduleLegend showCoverage={isAdmin} showEvents={isAdmin} />
+      </div>
     </div>
   );
 };

--- a/calendar-api-frontend/src/components/ScheduleCalendar/Shift.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/Shift.tsx
@@ -1,7 +1,9 @@
 import { useUserSettings } from "@/providers/useUserSettings";
 import {
-  calculateGridColumnSpan,
-  calculateGridColumnStart,
+  columnSpan,
+  columnStart,
+  dayBounds,
+  positionDisplay,
   prettyTimeRange,
 } from "./scheduleUtils";
 import type { Shift } from "@/types/shiftTypes";
@@ -9,15 +11,32 @@ import { Dialog, DialogTrigger } from "../ui/dialog";
 import { useState, useMemo, useEffect } from "react";
 import { EditShiftDialog } from "./EditShiftDIalog";
 import { useSchedule } from "@/providers/useSchedule";
+import { cn } from "@/lib/utils";
 
 type ShiftProps = {
   shift: Shift;
   selectedDate: Date;
+  /** 1-based lane from packLanes, so overlapping shifts stack instead of collide. */
+  lane: number;
   reloadScheduleCalendar: () => void;
 };
 
+/**
+ * Perceived lightness of a hex color, used to decide whether a saturated fill needs
+ * white or dark text. Positions are admin-picked, so we can't assume the palette.
+ */
+const isLightColor = (hex: string) => {
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!match) return false;
+  const value = parseInt(match[1], 16);
+  const r = (value >> 16) & 255;
+  const g = (value >> 8) & 255;
+  const b = value & 255;
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.68;
+};
+
 export function Shift(props: ShiftProps) {
-  const { shift, selectedDate, reloadScheduleCalendar } = props;
+  const { shift, selectedDate, lane, reloadScheduleCalendar } = props;
   const {
     setShiftInDrag,
     isBulkSelectorActive,
@@ -28,21 +47,12 @@ export function Shift(props: ShiftProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isSelected, setIsSelected] = useState(false);
 
-  // Memoize these calculations
-  const start = useMemo(
-    () => calculateGridColumnStart(shift.startTime, String(selectedDate)),
-    [shift.startTime, selectedDate]
-  );
-
   const span = useMemo(
-    () =>
-      calculateGridColumnSpan(
-        shift.startTime,
-        shift.endTime,
-        String(selectedDate)
-      ),
+    () => dayBounds(shift.startTime, shift.endTime, selectedDate),
     [shift.startTime, shift.endTime, selectedDate]
   );
+  const start = columnStart(span.start);
+  const cols = columnSpan(span);
 
   useEffect(() => {
     if (bulkSelectedShifts) {
@@ -55,19 +65,13 @@ export function Shift(props: ShiftProps) {
     }
   }, [bulkSelectedShifts]);
 
-  const currPosition = useMemo(() => {
-    const position = allPositions.find((pos) => shift.positionId === pos._id);
-    return (
-      position || {
-        name: "Unknown",
-        color: "#000000",
-        _id: "0",
-        positionId: "0",
-        type: "break",
-        sync: false,
-      }
-    );
-  }, [allPositions, shift.positionId]);
+  const position = useMemo(
+    () =>
+      positionDisplay(
+        allPositions.find((pos) => String(shift.positionId) === String(pos._id))
+      ),
+    [allPositions, shift.positionId]
+  );
 
   const handleDragStart = () => {
     if (userType === "admin") {
@@ -97,71 +101,124 @@ export function Shift(props: ShiftProps) {
     setBulkSelectedShifts(updatedShifts);
   };
 
-  const shiftStyleBulkActive = useMemo(
-    () => ({
-      gridColumnStart: start,
-      gridColumnEnd: `span ${span}`,
-      backgroundColor: `color-mix(in srgb, ${currPosition?.color} 95%, hsl(var(--shiftmix)) 20%)`,
-      fontSize: "0.6875rem",
-      cursor: userType === "admin" ? "pointer" : "default",
-      border: isSelected ? "2px solid white " : "none",
-    }),
-    [start, span, currPosition, userType, isSelected]
+  /**
+   * Content degrades with width instead of truncating into nothing: the time goes
+   * first (the hour ruler already says when), then the label falls back to a
+   * two-letter code. The full name and time are always on the hover title.
+   */
+  const mode =
+    cols >= 6 ? "full" : cols >= 3 ? "label" : cols === 2 ? "tight" : "code";
+
+  const toneStyle = useMemo(() => {
+    if (position.tone === "loud") {
+      return {
+        backgroundColor: position.color,
+        color: isLightColor(position.color)
+          ? "hsl(var(--foreground))"
+          : "#ffffff",
+      };
+    }
+    if (position.tone === "mid") {
+      return {
+        backgroundColor: `color-mix(in srgb, ${position.color} 16%, hsl(var(--card)))`,
+        border: `1px solid color-mix(in srgb, ${position.color} 42%, transparent)`,
+        color: "hsl(var(--foreground))",
+      };
+    }
+    return {
+      backgroundColor: "hsl(var(--muted))",
+      border: "1px dashed hsl(var(--border))",
+      color: "hsl(var(--muted-foreground))",
+    };
+  }, [position]);
+
+  // Overnight shifts clipped from an adjacent day lose the rounded corner and the
+  // margin on the side they continue from, so they read as running off-screen.
+  const radius = `${span.clippedStart ? "0" : "6px"} ${
+    span.clippedEnd ? "0" : "6px"
+  } ${span.clippedEnd ? "0" : "6px"} ${span.clippedStart ? "0" : "6px"}`;
+
+  const blockStyle = {
+    gridColumnStart: start,
+    gridColumnEnd: `span ${cols}`,
+    gridRowStart: lane,
+    marginLeft: span.clippedStart ? 0 : 2,
+    marginRight: span.clippedEnd ? 0 : 2,
+    borderRadius: radius,
+    cursor: userType === "admin" ? "pointer" : "default",
+    ...toneStyle,
+    ...(isBulkSelectorActive && isSelected
+      ? { outline: "2px solid hsl(var(--foreground))", outlineOffset: "-2px" }
+      : {}),
+  };
+
+  const title = `${position.name} · ${prettyTimeRange(
+    shift.startTime,
+    shift.endTime
+  )}`;
+
+  const body =
+    mode === "full" ? (
+      <div className="flex flex-col justify-center h-full px-2 overflow-hidden pointer-events-none">
+        <div className="text-[11px] font-bold tabular-nums leading-tight truncate">
+          {prettyTimeRange(shift.startTime, shift.endTime)}
+        </div>
+        <div className="text-[10.5px] font-medium leading-tight truncate opacity-90">
+          {position.label}
+        </div>
+      </div>
+    ) : mode === "label" ? (
+      <div className="flex items-center h-full px-1.5 overflow-hidden pointer-events-none">
+        <span className="text-[11px] font-semibold truncate">
+          {position.label}
+        </span>
+      </div>
+    ) : mode === "tight" ? (
+      <div className="flex items-center h-full px-1.5 overflow-hidden pointer-events-none">
+        <span className="text-[10px] font-semibold tracking-tight truncate">
+          {position.label}
+        </span>
+      </div>
+    ) : (
+      <div className="flex items-center justify-center h-full px-px overflow-hidden pointer-events-none">
+        <span className="text-[9.5px] font-semibold">{position.code}</span>
+      </div>
+    );
+
+  const blockClass = cn(
+    "pointer-events-auto overflow-hidden select-none",
+    userType === "admin" && !isBulkSelectorActive && "hover:brightness-110"
   );
 
   return isBulkSelectorActive ? (
     <div
-      onClick={() => toggleSelected()}
-      className={`p-1 m-[0.2rem] z-10 overflow-hidden whitespace-nowrap truncate rounded text-white h-11 flex flex-col justify-between`}
-      onMouseEnter={(e) => {
-        if (userType === "admin") {
-          e.currentTarget.style.backgroundColor = `color-mix(in srgb, ${currPosition?.color} 80%, hsl(0, 0%, 100%) 20%)`;
-        }
-      }}
-      onMouseLeave={(e) => {
-        if (userType === "admin") {
-          e.currentTarget.style.backgroundColor = `color-mix(in srgb, ${currPosition?.color} 95%, hsl(var(--shiftmix)) 20%)`;
-        }
-      }}
-      style={shiftStyleBulkActive}
+      onClick={toggleSelected}
+      title={title}
+      className={blockClass}
+      style={blockStyle}
     >
-      <div>
-        <div className="font-bold truncate">
-          {prettyTimeRange(shift.startTime, shift.endTime)}
-        </div>
-        <div className="truncate">{currPosition?.name}</div>
-      </div>
+      {body}
     </div>
   ) : (
-    <div
-      draggable="true"
-      onDragStart={handleDragStart}
-      className={`p-1 m-[0.2rem] z-10 overflow-hidden whitespace-nowrap truncate rounded text-white h-11 flex flex-col justify-between `}
-      style={{
-        gridColumnStart: start,
-        gridColumnEnd: `span ${span}`,
-        backgroundColor: `color-mix(in srgb, ${currPosition?.color} 95%, hsl(var(--shiftmix)) 20%)`,
-        fontSize: "0.6875rem",
-        cursor: userType === "admin" ? "pointer" : "default",
-      }}
-    >
-      <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogTrigger asChild>
-          <div>
-            <div className="font-bold truncate">
-              {prettyTimeRange(shift.startTime, shift.endTime)}
-            </div>
-            <div className="truncate">{currPosition?.name}</div>
-          </div>
-        </DialogTrigger>
-        {userType === "admin" && (
-          <EditShiftDialog
-            shift={shift}
-            setIsOpen={setIsOpen}
-            reloadScheduleCalendar={reloadScheduleCalendar}
-          />
-        )}
-      </Dialog>
-    </div>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <div
+          draggable={userType === "admin"}
+          onDragStart={handleDragStart}
+          title={title}
+          className={blockClass}
+          style={blockStyle}
+        >
+          {body}
+        </div>
+      </DialogTrigger>
+      {userType === "admin" && (
+        <EditShiftDialog
+          shift={shift}
+          setIsOpen={setIsOpen}
+          reloadScheduleCalendar={reloadScheduleCalendar}
+        />
+      )}
+    </Dialog>
   );
 }

--- a/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/AgentRow.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/AgentRow.tsx
@@ -1,0 +1,253 @@
+import { useMemo } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@radix-ui/react-avatar";
+import { CalendarIcon, RepeatIcon } from "lucide-react";
+import { Markup } from "interweave";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { Button } from "@/components/ui/button";
+import { UserSafeInfo } from "@/types/userTypes";
+import { Shift as ShiftType } from "@/types/shiftTypes";
+import { GCalEventWithGrid } from "@/types/gCalendarTypes";
+import { Position } from "@/types/positionTypes";
+import { Shift } from "../Shift";
+import EmptySlot from "./EmptySlot";
+import {
+  columnSpan,
+  columnStart,
+  dayBounds,
+  packLanes,
+  prettyGCalTime,
+  scheduledHours,
+} from "../scheduleUtils";
+import { cn } from "@/lib/utils";
+
+type AgentRowProps = {
+  user: UserSafeInfo;
+  shifts: ShiftType[];
+  events: GCalEventWithGrid[];
+  positionsById: Map<string, Position>;
+  selectedDate: Date;
+  isVisitor: boolean;
+  reloadScheduleCalendar: () => void;
+};
+
+/** Fixed geometry for variant B. */
+const SHIFT_LANE = 22;
+const EVENT_LANE = 9;
+const LANE_GAP = 2;
+const LANE_PADDING = 5;
+
+/**
+ * Hour-line pitch for the lane background, as a fraction of the lane's own width.
+ *
+ * It has to be relative: the 48 half-hour columns are `minmax(26px, 1fr)`, so an hour
+ * is only 52px when the track sits at its 1500px minimum and stretches past that on
+ * any wider window. A fixed pixel pitch drifts further out of step with the hour ruler
+ * every hour across the day.
+ */
+const HOUR_LINE_PITCH = "calc(100% / 24)";
+
+const formatHours = (hours: number) => {
+  const rounded = Math.round(hours * 2) / 2;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+};
+
+/**
+ * One agent's row: a sticky identity cell plus a lane-packed timeline.
+ *
+ * Shifts that overlap stack into separate lanes rather than painting over each
+ * other, and the row's height falls out of the lane count — which is what replaces
+ * the old ragged `rem` heights derived from an adjacent-pair overlap guess.
+ */
+const AgentRow = ({
+  user,
+  shifts,
+  events,
+  positionsById,
+  selectedDate,
+  isVisitor,
+  reloadScheduleCalendar,
+}: AgentRowProps) => {
+  const shiftLanes = useMemo(() => {
+    const spans = shifts.map((shift) => ({
+      shift,
+      ...dayBounds(shift.startTime, shift.endTime, selectedDate),
+    }));
+    return packLanes(spans);
+  }, [shifts, selectedDate]);
+
+  const eventLanes = useMemo(() => {
+    const spans = events.map((event) => ({
+      event,
+      ...dayBounds(event.start.dateTime, event.end.dateTime, selectedDate),
+    }));
+    return packLanes(spans);
+  }, [events, selectedDate]);
+
+  const shiftLaneCount = shifts.length === 0 ? 1 : shiftLanes.laneCount;
+  const eventLaneCount = events.length === 0 ? 0 : eventLanes.laneCount;
+
+  const totalHours = useMemo(
+    () => scheduledHours(shifts, positionsById, selectedDate),
+    [shifts, positionsById, selectedDate]
+  );
+
+  const rowHeight =
+    shiftLaneCount * SHIFT_LANE +
+    eventLaneCount * EVENT_LANE +
+    (shiftLaneCount + eventLaneCount - 1) * LANE_GAP +
+    LANE_PADDING * 2;
+
+  return (
+    <div
+      className={cn(
+        "grid border-b border-border-subtle",
+        isVisitor ? "bg-me-tint" : "bg-card"
+      )}
+      style={{ gridTemplateColumns: "252px repeat(48, minmax(26px, 1fr))" }}
+    >
+      <div
+        className={cn(
+          "sticky left-0 z-[3] flex items-center gap-[9px] border-r border-border px-3.5",
+          isVisitor ? "bg-me-tint" : "bg-card"
+        )}
+        style={{ height: rowHeight }}
+      >
+        <Avatar className="shrink-0">
+          <AvatarImage
+            src={user.imageUrl}
+            className="h-[22px] w-[22px] rounded-full"
+          />
+          <AvatarFallback className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-muted text-[10.5px] font-semibold text-foreground">
+            {`${user.firstName?.[0] ?? ""}${user.lastName?.[0] ?? ""}`}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0">
+          <div className="truncate text-[12.5px] font-semibold leading-tight">
+            {`${user.firstName} ${user.lastName}`}
+          </div>
+          <div className="truncate text-[10.5px] leading-tight text-muted-foreground">
+            {totalHours > 0
+              ? `${formatHours(totalHours)}h scheduled`
+              : "unavailable"}
+          </div>
+        </div>
+      </div>
+
+      {/* The timeline. EmptySlot cells sit underneath as the click/drop target; the
+          lane grid floats above with pointer-events off so gaps fall through. */}
+      <div
+        className="relative"
+        style={{ gridColumn: "span 48", height: rowHeight }}
+      >
+        <div
+          className="absolute inset-0 grid"
+          style={{ gridTemplateColumns: "repeat(24, minmax(0, 1fr))" }}
+        >
+          {Array.from({ length: 24 }, (_, hour) => (
+            <EmptySlot
+              key={`${user.id}-${hour}`}
+              userId={String(user.id)}
+              currentHour={hour}
+              selectedDate={selectedDate}
+            />
+          ))}
+        </div>
+
+        <div
+          className="pointer-events-none absolute inset-0 grid"
+          style={{
+            gridTemplateColumns: "repeat(48, minmax(26px, 1fr))",
+            gridTemplateRows: `repeat(${shiftLaneCount}, ${SHIFT_LANE}px) repeat(${eventLaneCount}, ${EVENT_LANE}px)`,
+            gap: `${LANE_GAP}px 0`,
+            padding: `${LANE_PADDING}px 0`,
+            backgroundImage: `repeating-linear-gradient(to right, hsl(var(--border-subtle)) 0 1px, transparent 1px ${HOUR_LINE_PITCH})`,
+          }}
+        >
+          {shiftLanes.placed.map(({ item, lane }) => (
+            <Shift
+              key={item.shift._id}
+              shift={item.shift}
+              lane={lane}
+              selectedDate={selectedDate}
+              reloadScheduleCalendar={reloadScheduleCalendar}
+            />
+          ))}
+
+          {eventLanes.placed.map(({ item, lane }) => {
+            const event = item.event;
+            return (
+              <HoverCard key={event.id}>
+                <HoverCardTrigger asChild>
+                  <div
+                    className="pointer-events-auto mx-[2px] flex items-center overflow-hidden truncate rounded-[4px] border border-border bg-muted px-1 text-[9.5px] font-medium leading-none text-muted-foreground"
+                    title={event.summary}
+                    style={{
+                      gridColumnStart: columnStart(item.start),
+                      gridColumnEnd: `span ${columnSpan(item)}`,
+                      gridRowStart: shiftLaneCount + lane,
+                    }}
+                  >
+                    <span className="truncate">{event.summary}</span>
+                  </div>
+                </HoverCardTrigger>
+                <HoverCardContent className="grid w-full max-w-md gap-6 p-6">
+                  <div className="flex items-start gap-4">
+                    <div className="flex aspect-square w-12 items-center justify-center rounded-md bg-muted">
+                      <CalendarIcon className="h-6 w-6" />
+                    </div>
+                    <div className="grid gap-1">
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-xl font-semibold">
+                          {event.summary}
+                        </h3>
+                        {event.recurringEventId && (
+                          <RepeatIcon className="h-5 w-5 text-muted-foreground" />
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <CalendarIcon className="h-4 w-4" />
+                        <span>
+                          {prettyGCalTime(
+                            event.start.dateTime,
+                            event.end.dateTime
+                          )}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <p className="max-h-28 truncate text-muted-foreground">
+                    <Markup content={event.description} />
+                  </p>
+                  <div className="flex gap-4">
+                    <Button asChild variant="link">
+                      <a href={event.htmlLink} target="_blank" rel="noreferrer">
+                        See more
+                      </a>
+                    </Button>
+                    {event.hangoutLink && (
+                      <Button>
+                        <a
+                          href={event.hangoutLink}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Join meeting
+                        </a>
+                      </Button>
+                    )}
+                  </div>
+                </HoverCardContent>
+              </HoverCard>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AgentRow;

--- a/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/CalendarHeader.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/CalendarHeader.tsx
@@ -1,31 +1,52 @@
-const CalendarHeader = () => {
-  const hours = Array.from({ length: 24 }, (_, i) => `${i}:00`);
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type CalendarHeaderProps = {
+  /** Shown in the sticky left cell, e.g. `16 agents`. */
+  agentCount: number;
+  /** Highlight the current hour only when the grid is actually showing today. */
+  isToday: boolean;
+};
+
+/**
+ * The hour ruler: row one of the grid. Each hour spans two of the 48 half-hour
+ * columns. The left cell is sticky so it stays put while the timeline scrolls — the
+ * whole grid now shares one horizontal scroll container instead of one per row.
+ */
+const CalendarHeader = ({ agentCount, isToday }: CalendarHeaderProps) => {
+  const [currentHour, setCurrentHour] = useState(() => new Date().getHours());
+
+  useEffect(() => {
+    const timer = setInterval(
+      () => setCurrentHour(new Date().getHours()),
+      60_000
+    );
+    return () => clearInterval(timer);
+  }, []);
 
   return (
-    <div className="flex sticky top-16 bg-background z-20">
-      <div className="py-2" style={{ width: "12%" }}></div>
-      <div className="flex-1 overflow-x-auto">
-        <div
-          className="grid"
-          style={{ gridTemplateColumns: "repeat(48, minmax(0, 1fr))" }}
-        >
-          {Array.from({ length: 48 }, (_, i) => (
-            <div
-              key={i}
-              className={`col-span-2 border-r text-center text-xs font-bold truncate font-semibold py-4 ${
-                i % 2 === 0 ? "" : "hidden"
-              } ${
-                new Date().getHours() === i / 2
-                  ? "bg-secondary/80"
-                  : "background"
-              }`}
-              style={{ gridColumn: `span 2` }}
-            >
-              {i % 2 === 0 && hours[i / 2]}
-            </div>
-          ))}
-        </div>
+    <div
+      className="grid border-b border-border"
+      style={{ gridTemplateColumns: "252px repeat(48, minmax(26px, 1fr))" }}
+    >
+      <div className="sticky left-0 z-[3] flex items-center border-r border-border bg-card px-3.5 py-2.5 text-[11px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+        {agentCount} {agentCount === 1 ? "agent" : "agents"}
       </div>
+
+      {Array.from({ length: 24 }, (_, hour) => (
+        <div
+          key={hour}
+          className={cn(
+            "border-l border-border-subtle pb-[9px] pt-2.5 text-center text-[11px] font-semibold tabular-nums",
+            isToday && currentHour === hour
+              ? "bg-me-tint text-foreground"
+              : "text-muted-foreground"
+          )}
+          style={{ gridColumn: "span 2" }}
+        >
+          {String(hour).padStart(2, "0")}
+        </div>
+      ))}
     </div>
   );
 };

--- a/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/CoverageRow.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/CoverageRow.tsx
@@ -1,0 +1,127 @@
+import { useMemo } from "react";
+import { CoverageMeter } from "@/types/coverageTypes";
+import { SortedCalendar } from "@/types/shiftTypes";
+import { UserSafeInfo } from "@/types/userTypes";
+import {
+  SLOTS_PER_DAY,
+  buildCoverageSeries,
+  formatSlotTime,
+} from "../scheduleUtils";
+import { cn } from "@/lib/utils";
+
+type CoverageRowProps = {
+  meter: CoverageMeter;
+  roster: UserSafeInfo[];
+  shifts: SortedCalendar;
+  selectedDate: Date;
+  /** Draw the per-hour target ticks. */
+  showTargets: boolean;
+};
+
+const ROW_HEIGHT = 52;
+const COUNT_HEIGHT = 13;
+const CELL_PADDING_Y = 4;
+const TRACK_HEIGHT = ROW_HEIGHT - COUNT_HEIGHT - CELL_PADDING_Y * 2;
+
+/**
+ * One histogram row per configured meter: how many agents are on the meter's
+ * positions in each half hour, measured against that half hour's target.
+ *
+ * This is the answer to "is 14:00–16:00 covered?", which the old grid had no way of
+ * showing. Admin-only — the caller decides whether to render it at all.
+ */
+const CoverageRow = ({
+  meter,
+  roster,
+  shifts,
+  selectedDate,
+  showTargets,
+}: CoverageRowProps) => {
+  const series = useMemo(
+    () => buildCoverageSeries(meter, roster, shifts, selectedDate),
+    [meter, roster, shifts, selectedDate]
+  );
+
+  const isShort = series.summary.includes("short");
+
+  return (
+    <div
+      className="grid border-b border-border-subtle bg-band"
+      style={{ gridTemplateColumns: "252px repeat(48, minmax(26px, 1fr))" }}
+    >
+      <div
+        className="sticky left-0 z-[3] flex flex-col justify-center border-r border-border bg-band px-3.5"
+        style={{ height: ROW_HEIGHT }}
+      >
+        <div className="flex items-center gap-[7px]">
+          <span
+            className="h-2 w-2 shrink-0 rounded-[2px]"
+            style={{ backgroundColor: meter.color }}
+          />
+          <span className="truncate text-[11.5px] font-semibold">
+            {meter.name}
+          </span>
+        </div>
+        <div
+          className={cn(
+            "ml-[15px] truncate text-[10.5px]",
+            isShort ? "text-warn" : "text-muted-foreground"
+          )}
+        >
+          {series.summary}
+        </div>
+      </div>
+
+      {Array.from({ length: SLOTS_PER_DAY }, (_, slot) => {
+        const count = series.counts[slot];
+        const target = series.targets[slot];
+        const below = count < target;
+
+        const barHeight = Math.round((count / series.peak) * TRACK_HEIGHT);
+        const tickBottom =
+          Math.round((target / series.peak) * TRACK_HEIGHT) - 1;
+
+        return (
+          <div
+            key={slot}
+            className={cn(
+              "flex flex-col justify-end px-[1.5px] py-1",
+              below && "bg-warn-bg"
+            )}
+            title={`${formatSlotTime(slot)} · ${count} scheduled · target ${target}`}
+          >
+            <div
+              className={cn(
+                "text-center text-[9px] font-bold leading-none tabular-nums",
+                below ? "text-warn" : "text-muted-foreground"
+              )}
+              style={{ height: COUNT_HEIGHT }}
+            >
+              {count > 0 ? count : ""}
+            </div>
+            <div
+              className="relative rounded-[2px] border-b border-border-subtle"
+              style={{ height: TRACK_HEIGHT }}
+            >
+              <div
+                className="absolute bottom-0 left-0 right-0 rounded-t-[2px]"
+                style={{
+                  height: barHeight,
+                  backgroundColor: below ? "hsl(var(--warn))" : meter.color,
+                }}
+              />
+              {showTargets && target > 0 && (
+                <div
+                  className="absolute left-0 right-0 h-[2px] bg-muted-foreground/50"
+                  style={{ bottom: Math.max(0, tickBottom) }}
+                />
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CoverageRow;

--- a/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/EmptySlot.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/EmptySlot.tsx
@@ -7,13 +7,12 @@ import { toast } from "sonner";
 
 type EmptySlotProps = {
   userId: string;
-  visitorId: string;
   currentHour: number;
   selectedDate: Date;
 };
 
 function EmptySlot(props: EmptySlotProps) {
-  const { userId, visitorId, currentHour, selectedDate } = props;
+  const { userId, currentHour, selectedDate } = props;
   const { type: userType } = useUserSettings();
   const { shiftInDrag, setShiftInDrag, shifts, setShifts, events, setEvents } =
     useSchedule();
@@ -63,40 +62,42 @@ function EmptySlot(props: EmptySlotProps) {
     }
 
     const createdShift = responseData.data;
+    const targetUserId = createdShift.userId;
 
-    if (!shifts[createdShift.userId]) {
-      shifts[createdShift.userId] = [];
-    }
+    // Replace every level rather than mutating in place: the grid memoises each
+    // agent's lane packing on their own shift array, so an array that keeps its
+    // identity leaves the moved shift invisible until a reload. Filtering the
+    // target as well as the source keeps a same-agent drop from duplicating it.
+    const withoutMoved = (userShifts: Shift[] | undefined) =>
+      (userShifts ?? []).filter((shift) => shift._id !== createdShift._id);
 
-    const prevUserShifts = shifts[prevUserId].filter(
-      (shift) => shift._id !== createdShift._id
-    );
-    console.log("createdShift", createdShift);
-    console.log("prevUserShifts", prevUserShifts);
-    shifts[prevUserId] = prevUserShifts;
-
-    shifts[createdShift.userId].push(createdShift);
-
-    shifts[createdShift.userId].sort(
+    const updated = { ...shifts };
+    updated[prevUserId] = withoutMoved(updated[prevUserId]);
+    updated[targetUserId] = [
+      ...withoutMoved(updated[targetUserId]),
+      createdShift,
+    ].sort(
       (a, b) =>
         new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
     );
 
-    setShifts({ ...shifts });
+    setShifts(updated);
 
     if (createdShift.isSynced) {
-      events
-        .find((event) => event.userId === createdShift.userId)
-        ?.events.push(createdShift.syncedEvent);
-      events
-        .find((event) => event.userId === createdShift.userId)
-        ?.events.sort((a, b) => {
-          return (
-            new Date(a.start.dateTime).getTime() -
-            new Date(b.start.dateTime).getTime()
-          );
-        });
-      setEvents([...events]);
+      setEvents(
+        events.map((calendarUser) =>
+          calendarUser.userId === targetUserId
+            ? {
+                ...calendarUser,
+                events: [...calendarUser.events, createdShift.syncedEvent].sort(
+                  (a, b) =>
+                    new Date(a.start.dateTime).getTime() -
+                    new Date(b.start.dateTime).getTime()
+                ),
+              }
+            : calendarUser
+        )
+      );
     }
   };
 
@@ -124,42 +125,27 @@ function EmptySlot(props: EmptySlotProps) {
     }
   };
 
-  return userType === "admin" ? (
+  // One cell per hour, sitting underneath the shift lanes as a full-height click and
+  // drop target. The row's hour lines and tint are drawn by AgentRow, so these cells
+  // stay transparent — they exist for the interaction, not the paint.
+  if (userType !== "admin") return <div key={`key-${currentHour}`} />;
+
+  return (
     <CreateShiftDialog selectedDate={date} selectedUserId={userId}>
       <div
         key={`key-${currentHour}`}
         className={cn(
-          "border-r",
-          String(userId) === String(visitorId)
-            ? "border-primary/20"
-            : "border-secondary",
-          new Date().getHours() === currentHour
-            ? "bg-secondary/80"
-            : "background"
+          "group flex h-full cursor-pointer items-center justify-center",
+          "hover:bg-foreground/[0.04]"
         )}
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
       >
-        <div
-          className={
-            "m-1 h-10 hover:border-2 justify-center items-center cursor-pointer flex group"
-          }
-        >
-          <span className="group-hover:block hidden">+</span>
-        </div>
+        <span className="hidden text-[11px] leading-none text-muted-foreground group-hover:block">
+          +
+        </span>
       </div>
     </CreateShiftDialog>
-  ) : (
-    <div
-      key={`key-${currentHour}`}
-      className={cn(
-        "border-r",
-        String(userId) === String(visitorId)
-          ? "border-primary/20"
-          : "border-secondary",
-        new Date().getHours() === currentHour ? "bg-secondary/80" : "background"
-      )}
-    ></div>
   );
 }
 

--- a/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/NowLine.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/NowLine.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+type NowLineProps = {
+  /** Only drawn when the grid is showing today. */
+  isToday: boolean;
+};
+
+const AGENT_COLUMN = 252;
+
+/**
+ * The "now" marker, absolutely positioned inside the scroll track so it moves with
+ * the timeline. Positioned as a percentage of the timeline's width rather than a
+ * fixed pixel offset, so it stays correct when the track stretches past its 1500px
+ * minimum to fill a wide screen.
+ */
+const NowLine = ({ isToday }: NowLineProps) => {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (!isToday) return null;
+
+  const fractionOfDay =
+    (now.getHours() * 60 + now.getMinutes()) / (24 * 60);
+  const label = `${String(now.getHours()).padStart(2, "0")}:${String(
+    now.getMinutes()
+  ).padStart(2, "0")}`;
+
+  return (
+    <div
+      className="pointer-events-none absolute bottom-0 top-0 z-[5] w-[2px] bg-warn"
+      style={{
+        left: `calc(${AGENT_COLUMN}px + (100% - ${AGENT_COLUMN}px) * ${fractionOfDay})`,
+      }}
+    >
+      <div className="absolute -left-[22px] top-0 rounded-[5px] bg-warn px-1.5 py-0.5 text-[9.5px] font-bold tabular-nums text-background">
+        {label}
+      </div>
+    </div>
+  );
+};
+
+export default NowLine;

--- a/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/ScheduleLegend.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/ScheduleLegend.tsx
@@ -1,0 +1,38 @@
+type ScheduleLegendProps = {
+  /** Coverage entries only mean something to an admin, who is the only one who sees the rows. */
+  showCoverage: boolean;
+  /** Only mention Google Calendar when the under-lane can actually appear. */
+  showEvents: boolean;
+};
+
+/**
+ * Footer inside the grid card. Deliberately no position legend — there are too many
+ * positions for one to be useful, and every block carries its full name on hover.
+ */
+const ScheduleLegend = ({ showCoverage, showEvents }: ScheduleLegendProps) => (
+  <div className="flex flex-wrap items-center gap-3.5 border-t border-border bg-band px-4 py-[9px] text-[11px] text-muted-foreground">
+    {showEvents && (
+      <span className="flex items-center gap-1.5">
+        <span className="h-2 w-4 rounded-[3px] border border-border bg-muted" />
+        Google Calendar
+      </span>
+    )}
+    {showCoverage && (
+      <>
+        <span className="flex items-center gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-[2px] bg-warn" />
+          Below target
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-[2px] w-3.5 bg-muted-foreground/50" />
+          Hourly target
+        </span>
+        <span className="ml-auto">
+          Targets per hour are set in Settings → Coverage
+        </span>
+      </>
+    )}
+  </div>
+);
+
+export default ScheduleLegend;

--- a/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/ScheduleToolbar.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/ScheduleToolbar.tsx
@@ -1,0 +1,101 @@
+import { ChevronLeft, ChevronRight, CalendarSearch } from "lucide-react";
+import { Label } from "@radix-ui/react-label";
+import { Input } from "@/components/ui/input";
+import CreateShiftForm from "../CreateShiftBtn";
+import DuplicateShifts from "../DuplicateShifts";
+import ToggleBulkSelector from "./ToggleBulkSelector";
+
+type ScheduleToolbarProps = {
+  selectedDate: Date;
+  onSelectDate: (date: Date) => void;
+  isToday: boolean;
+};
+
+/** A given Date, shifted by `delta` days and normalised to local midnight. */
+const addDays = (date: Date, delta: number): Date =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate() + delta);
+
+/**
+ * The schedule's own toolbar.
+ *
+ * The date stepper is local rather than the shared `DateNavButtons` on purpose:
+ * that component is also used by /app/sling-schedule, which this redesign leaves
+ * alone. Same behaviour, different chrome.
+ */
+const ScheduleToolbar = ({
+  selectedDate,
+  onSelectDate,
+  isToday,
+}: ScheduleToolbarProps) => (
+  <div className="flex flex-wrap items-end gap-4 px-5 pb-3.5 pt-5">
+    <div className="min-w-0">
+      <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+        Schedule · Agendo
+      </div>
+      <div className="flex items-center gap-2.5">
+        <h1 className="whitespace-nowrap font-sf text-[22px] font-semibold tracking-[-0.01em]">
+          {selectedDate.toLocaleDateString("en-US", {
+            weekday: "long",
+            month: "long",
+            day: "numeric",
+          })}
+        </h1>
+        {isToday && (
+          <span className="flex h-[22px] items-center rounded-md bg-muted px-2 text-[11px] font-semibold text-muted-foreground">
+            Today
+          </span>
+        )}
+      </div>
+    </div>
+
+    {/* Prev · Today · Next, glued into one bordered control. */}
+    <div className="flex h-[34px] items-stretch overflow-hidden rounded-lg border border-border">
+      <button
+        type="button"
+        aria-label="Previous day"
+        className="flex w-8 items-center justify-center hover:bg-muted"
+        onClick={() => onSelectDate(addDays(selectedDate, -1))}
+      >
+        <ChevronLeft size={15} />
+      </button>
+      <button
+        type="button"
+        className="border-x border-border px-3 text-[13px] font-medium hover:bg-muted"
+        onClick={() => onSelectDate(addDays(new Date(), 0))}
+      >
+        Today
+      </button>
+      <button
+        type="button"
+        aria-label="Next day"
+        className="flex w-8 items-center justify-center hover:bg-muted"
+        onClick={() => onSelectDate(addDays(selectedDate, 1))}
+      >
+        <ChevronRight size={15} />
+      </button>
+    </div>
+
+    {/* AirDatepicker attaches to #date — the id has to stay. */}
+    <Label htmlFor="date" className="relative flex">
+      <Input
+        id="date"
+        className="h-[34px] w-[112px] cursor-pointer rounded-lg pr-7 text-[13px]"
+        placeholder="Select a date"
+        value={selectedDate.toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+        })}
+        readOnly
+      />
+      <CalendarSearch className="pointer-events-none absolute right-2 top-1/2 h-[15px] w-[15px] -translate-y-1/2 text-muted-foreground" />
+    </Label>
+
+    <div className="ml-auto flex flex-wrap items-center gap-2.5">
+      <DuplicateShifts selectedDate={selectedDate} />
+      <ToggleBulkSelector />
+      <CreateShiftForm selectedDate={selectedDate} />
+    </div>
+  </div>
+);
+
+export default ScheduleToolbar;

--- a/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/ToggleBulkSelector.tsx
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/calendar-components/ToggleBulkSelector.tsx
@@ -1,42 +1,43 @@
-import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
 import { useSchedule } from "@/providers/useSchedule";
 // import BulkCopyBtn from "./BulkCopyBtn";
 import BulkDeleteBtn from "./BulkDeleteBtn";
 import BulkDeselectBtn from "./BulkDeselectBtn";
 import { useUserSettings } from "@/providers/useUserSettings";
+import { ListChecks } from "lucide-react";
 
+/**
+ * Enters bulk-select mode, which reveals per-shift selection on the grid.
+ *
+ * Behaviour is unchanged from the old `Bulk Select` switch — it's a button now
+ * because the toolbar is a row of buttons and a lone switch read as a setting rather
+ * than a mode you step into and back out of.
+ */
 function ToggleBulkSelector() {
   const { type } = useUserSettings();
   const { isBulkSelectorActive, setIsBulkSelectorActive } = useSchedule();
 
-  const toggleBulkSelector = () => {
-    setIsBulkSelectorActive(!isBulkSelectorActive);
-  };
+  if (type !== "admin") return null;
 
   return (
-    type === "admin" && (
-      <div
-        className={`flex space-x-3 ml-auto p-2 rounded-md border border-border px-4 ${
-          isBulkSelectorActive ? "pl-1" : ""
-        }`}
+    <div className="flex items-center gap-2">
+      <Button
+        variant={isBulkSelectorActive ? "secondary" : "outline"}
+        className="h-[34px] gap-[7px] whitespace-nowrap rounded-lg px-3 text-[13px]"
+        onClick={() => setIsBulkSelectorActive(!isBulkSelectorActive)}
       >
-        {isBulkSelectorActive && (
-          <div id="bulk-selector-active-buttons" className="h-5">
-            {/* <BulkCopyBtn /> */}
-            <BulkDeselectBtn />
-            <BulkDeleteBtn />
-          </div>
-        )}
-        <div className="flex items-center space-x-2">
-          <Switch
-            id="bulk-selector-toggle"
-            checked={isBulkSelectorActive}
-            onCheckedChange={toggleBulkSelector}
-          />
-          <p className="text-sm">Bulk Select</p>
+        <ListChecks size={15} />
+        {isBulkSelectorActive ? "Done selecting" : "Select shifts"}
+      </Button>
+
+      {isBulkSelectorActive && (
+        <div id="bulk-selector-active-buttons" className="flex items-center">
+          {/* <BulkCopyBtn /> */}
+          <BulkDeselectBtn />
+          <BulkDeleteBtn />
         </div>
-      </div>
-    )
+      )}
+    </div>
   );
 }
 

--- a/calendar-api-frontend/src/components/ScheduleCalendar/scheduleUtils.ts
+++ b/calendar-api-frontend/src/components/ScheduleCalendar/scheduleUtils.ts
@@ -7,6 +7,10 @@ import {
   GCalendarEvent,
   GCalendarEventList,
 } from "@/types/gCalendarTypes.ts";
+import { Position } from "@/types/positionTypes.ts";
+import { CoverageMeter } from "@/types/coverageTypes.ts";
+import { UserSafeInfo } from "@/types/userTypes.ts";
+import { targetAt } from "@/utils/coverageTargets.ts";
 import { toast } from "sonner";
 
 type GetCalEventsSuccessResponse = {
@@ -113,8 +117,10 @@ export const getGCalendarEvents = async (
           );
         });
 
-        const { numberOfEventOverlaps, eventsOrganized } =
-          calculateOverlaps(filteredEvents);
+        const { numberOfEventOverlaps, eventsOrganized } = assignEventLanes(
+          filteredEvents,
+          date
+        );
 
         return {
           ...user,
@@ -166,34 +172,6 @@ export const prettyTimeRange = (startRaw: string, endRaw: string) => {
   return `${start} - ${end}`;
 };
 
-export const calculateGridColumnStart = (
-  start: string,
-  dateToRender: string
-) => {
-  const startAsDate = new Date(start);
-  const dateToRenderAsDate = new Date(dateToRender);
-  if (startAsDate.getDate() < dateToRenderAsDate.getDate()) return 0; // Shift starts on previous day
-  const startHour = startAsDate.getHours();
-  const startMinutes = startAsDate.getMinutes();
-  const result = startHour * 2 + Math.floor(startMinutes / 30) + 1; // Assuming each column represents 30 minutes
-  return result;
-};
-
-export const calculateGridColumnSpan = (
-  start: string,
-  end: string,
-  dateToRender: string
-) => {
-  const startAsDate = new Date(start);
-  const endAdDate = new Date(end);
-  const dateRenderedAsDate = new Date(dateToRender);
-  if (startAsDate.getDate() < dateRenderedAsDate.getDate())
-    return endAdDate.getHours() * 2;
-  const durationInMinutes =
-    (endAdDate.getTime() - startAsDate.getTime()) / (1000 * 60);
-  return Math.ceil(durationInMinutes / 30); // Assuming each column represents 30 minutes
-};
-
 /** Formats Google Calendar event start and end times as 'pretty' string
  * @param {string} start - start time of the event
  * @param {string} end - end time of the event
@@ -220,97 +198,325 @@ export const prettyGCalTime = (start: string, end: string) => {
   return `${firstPart} to ${secondPart}`;
 };
 
-// export const calculateOverlapAmount = (events: GCalendarEventList) => {
-//   // Store unique overlap pairs to avoid counting same overlap twice
-//   const overlapSet = new Set<string>();
+/* -------------------------------------------------------------------------- */
+/* Grid math                                                                  */
+/* -------------------------------------------------------------------------- */
 
-//   events.forEach((event1, i) => {
-//     const start1 = new Date(event1.start.dateTime).getTime();
-//     const end1 = new Date(event1.end.dateTime).getTime();
+/** The timeline is 48 half-hour columns wide, one per slot. */
+export const SLOTS_PER_DAY = 48;
 
-//     const event2 = events[i + 1];
-//     if (event2) {
-//       const start2 = new Date(event2.start.dateTime).getTime();
-//       const end2 = new Date(event2.end.dateTime).getTime();
+/** A span in fractional local hours since the selected day's midnight, 0..24. */
+export type DaySpan = {
+  start: number;
+  end: number;
+  /** True when the item actually began before this day (clipped at column 1). */
+  clippedStart: boolean;
+  /** True when it runs past midnight (clipped at column 48). */
+  clippedEnd: boolean;
+};
 
-//       if (start1 < end2 && start2 < end1) {
-//         // Create unique identifier for this overlap pair
-//         const overlapId = [event1.id, event2.id].sort().join('-');
-//         overlapSet.add(overlapId);
-//       }
-//     }
-//   });
+export const startOfLocalDay = (date: Date): Date => {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  return start;
+};
 
-//   // Return total number of unique overlaps
-//   return overlapSet.size + 1;
-// };
+/**
+ * Clamp an absolute start/end onto the selected day's 0..24 hour axis.
+ *
+ * Overnight shifts are the reason this exists: a shift that began yesterday has to
+ * render from column 1 rather than from whatever `getHours()` happens to return, and
+ * one that runs past midnight has to stop at column 48. The `clipped*` flags let the
+ * block drop the rounded corner on the side it continues from.
+ */
+export const dayBounds = (
+  startIso: string,
+  endIso: string,
+  selectedDate: Date
+): DaySpan => {
+  const dayStart = startOfLocalDay(selectedDate).getTime();
+  const startHours = (new Date(startIso).getTime() - dayStart) / 3_600_000;
+  const endHours = (new Date(endIso).getTime() - dayStart) / 3_600_000;
+  const clamp = (value: number) => Math.min(24, Math.max(0, value));
 
-export const calculateOverlaps = (events: GCalendarEventList) => {
-  // Store unique overlap pairs to avoid counting same overlap twice
-  const eventRows: GCalendarEvent[][] = [];
-
-  const eventsWithGridNo = events.map((event, i) => {
-    const currEvent = { ...event };
-
-    if (i === 0) {
-      currEvent.gridRowNumber = 1;
-      eventRows[0] = [currEvent];
-      return currEvent;
-    }
-
-    const startCurr = new Date(currEvent.start.dateTime).getTime();
-    const endCurr = new Date(currEvent.end.dateTime).getTime();
-
-    eventRows.every((row, j) => {
-      const lastEvent = row[row.length - 1];
-      const startLast = new Date(lastEvent.start.dateTime).getTime();
-      const endLast = new Date(lastEvent.end.dateTime).getTime();
-
-      if (startLast < endCurr && startCurr < endLast) {
-        if (eventRows[j + 1]) return true;
-        currEvent.gridRowNumber = j + 2;
-        eventRows[j + 1] = [currEvent];
-        return false;
-      }
-
-      currEvent.gridRowNumber = j + 1;
-      eventRows[j].push(currEvent);
-      return false;
-    });
-
-    return currEvent;
-  });
-
-  // Return total number of unique overlaps
   return {
-    numberOfEventOverlaps: eventRows.length,
-    eventsOrganized: eventsWithGridNo,
+    start: clamp(startHours),
+    end: clamp(endHours),
+    clippedStart: startHours < 0,
+    clippedEnd: endHours > 24,
   };
 };
 
-export const calculateShiftOverlapAmount = (shifts: Shift[]) => {
-  const overlapSet = new Set<string>();
+/** 1-based CSS grid column for an hour offset, on the 48-column half-hour track. */
+export const columnStart = (hour: number) =>
+  Math.min(SLOTS_PER_DAY, Math.floor(hour * 2) + 1);
 
-  if (shifts?.length < 2 || !shifts) {
-    return 1;
-  }
+/** Column span for a duration, never less than one half-hour cell. */
+export const columnSpan = (span: DaySpan) => {
+  const cells = Math.round((span.end - span.start) * 2);
+  const start = columnStart(span.start);
+  return Math.max(1, Math.min(cells, SLOTS_PER_DAY - start + 1));
+};
 
-  shifts.forEach((shift1, i) => {
-    const start1 = new Date(shift1.startTime).getTime();
-    const end1 = new Date(shift1.endTime).getTime();
+export type LanePlacement<T> = { item: T; lane: number };
 
-    const shift2 = shifts[i + 1];
-    if (shift2) {
-      const start2 = new Date(shift2.startTime).getTime();
-      const end2 = new Date(shift2.endTime).getTime();
+/**
+ * Greedy first-fit lane packing: each item drops into the first lane where it
+ * overlaps nothing, otherwise it opens a new one. Used for both shifts and Google
+ * Calendar events.
+ *
+ * This replaces the old `calculateShiftOverlapAmount`, which only compared adjacent
+ * pairs (so it missed a shift overlapping a non-neighbour) and only produced a count,
+ * leaving blocks to paint over each other. Here every item gets an explicit lane, and
+ * `laneCount` gives the row its exact height instead of a ragged `rem` estimate.
+ */
+export const packLanes = <T extends { start: number; end: number }>(
+  items: T[]
+): { laneCount: number; placed: LanePlacement<T>[] } => {
+  const lanes: T[][] = [];
 
-      if (start1 < end2 && start2 < end1) {
-        // Create unique identifier for this overlap pair
-        const overlapId = [shift1._id, shift2._id].sort().join("-");
-        overlapSet.add(overlapId);
+  const placed = items.map((item) => {
+    for (let i = 0; i < lanes.length; i++) {
+      const fits = lanes[i].every(
+        (other) => other.end <= item.start || item.end <= other.start
+      );
+      if (fits) {
+        lanes[i].push(item);
+        return { item, lane: i + 1 };
       }
     }
+    lanes.push([item]);
+    return { item, lane: lanes.length };
   });
 
-  return overlapSet.size + 1; // Add 1 for base height
+  return { laneCount: Math.max(1, lanes.length), placed };
 };
+
+/** Lane-pack a user's Google Calendar events, writing the lane onto `gridRowNumber`. */
+const assignEventLanes = (events: GCalendarEventList, date: Date) => {
+  const spans = events.map((event) => ({
+    event,
+    ...dayBounds(event.start.dateTime, event.end.dateTime, date),
+  }));
+  const { laneCount, placed } = packLanes(spans);
+
+  return {
+    numberOfEventOverlaps: events.length === 0 ? 0 : laneCount,
+    eventsOrganized: placed.map(
+      ({ item, lane }): GCalendarEvent => ({
+        ...item.event,
+        gridRowNumber: lane,
+      })
+    ),
+  };
+};
+
+/* -------------------------------------------------------------------------- */
+/* Coverage                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export type CoverageSeries = {
+  counts: number[];
+  targets: number[];
+  peak: number;
+  summary: string;
+  hasTarget: boolean;
+};
+
+/**
+ * Slot 18 -> `09:00`, slot 19 -> `09:30`.
+ *
+ * Slot 48 is a valid *end* bound and renders as `24:00`, not `00:00` — a range that
+ * runs to midnight has to read as ending after it started.
+ */
+export const formatSlotTime = (slot: number) => {
+  const hour = String(Math.floor(slot / 2)).padStart(2, "0");
+  const minute = slot % 2 === 0 ? "00" : "30";
+  return `${hour}:${minute}`;
+};
+
+/**
+ * The one-line verdict in a coverage row's sticky cell. Reports the widest stretch
+ * that falls short (earliest wins a tie) and how deep the gap gets inside it, since
+ * that is what an admin scanning the row actually needs to act on.
+ */
+const summarize = (counts: number[], targets: number[], hasTarget: boolean) => {
+  if (!hasTarget) return "no target set";
+
+  type ShortRun = { from: number; to: number; deficit: number };
+  const runs: ShortRun[] = [];
+  let open: ShortRun | null = null;
+
+  for (let slot = 0; slot < SLOTS_PER_DAY; slot++) {
+    if (counts[slot] < targets[slot]) {
+      const deficit = targets[slot] - counts[slot];
+      if (open) {
+        open.to = slot + 1;
+        open.deficit = Math.max(open.deficit, deficit);
+      } else {
+        open = { from: slot, to: slot + 1, deficit };
+        runs.push(open);
+      }
+    } else {
+      open = null;
+    }
+  }
+
+  if (runs.length === 0) return "target met all day";
+
+  // Widest gap wins; earliest breaks a tie, since that is the one to fix first.
+  const worst = runs.reduce((a, b) => (b.to - b.from > a.to - a.from ? b : a));
+  if (worst.from === 0 && worst.to === SLOTS_PER_DAY) {
+    return `${worst.deficit} short all day`;
+  }
+  return `${worst.deficit} short between ${formatSlotTime(
+    worst.from
+  )} and ${formatSlotTime(worst.to)}`;
+};
+
+/**
+ * Head-count per half hour for one meter, against that meter's target.
+ *
+ * An agent counts in a slot when they have a shift on one of the meter's positions
+ * that fully covers the slot -- a shift ending at 09:15 does not cover 09:00-09:30.
+ *
+ * Targets are resolved from each slot's absolute instant rather than from a day/hour
+ * label, so this stays correct when the local day straddles two UTC days (which it
+ * does for most of the world) and across DST. See src/utils/coverageTargets.ts.
+ */
+export const buildCoverageSeries = (
+  meter: CoverageMeter,
+  roster: UserSafeInfo[],
+  shifts: SortedCalendar,
+  selectedDate: Date
+): CoverageSeries => {
+  const meterPositions = new Set(meter.positionIds.map(String));
+  const dayStart = startOfLocalDay(selectedDate).getTime();
+
+  const spansByUser = roster.map((user) =>
+    (shifts[user.id] ?? [])
+      .filter((shift) => meterPositions.has(String(shift.positionId)))
+      .map((shift) => dayBounds(shift.startTime, shift.endTime, selectedDate))
+  );
+
+  const counts: number[] = [];
+  const targets: number[] = [];
+
+  for (let slot = 0; slot < SLOTS_PER_DAY; slot++) {
+    const slotStart = slot / 2;
+    const slotEnd = slotStart + 0.5;
+
+    counts.push(
+      spansByUser.filter((spans) =>
+        spans.some((span) => span.start <= slotStart && span.end >= slotEnd)
+      ).length
+    );
+    targets.push(targetAt(meter, new Date(dayStart + slot * 30 * 60_000)));
+  }
+
+  const peak = Math.max(1, ...counts, ...targets);
+  const hasTarget = targets.some((target) => target > 0);
+
+  return {
+    counts,
+    targets,
+    peak,
+    hasTarget,
+    summary: summarize(counts, targets, hasTarget),
+  };
+};
+
+/* -------------------------------------------------------------------------- */
+/* Positions                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/** How loudly a position's block is painted. See positionDisplay. */
+export type PositionTone = "loud" | "mid" | "quiet";
+
+export type PositionDisplay = {
+  name: string;
+  color: string;
+  /** Short form that fits a 1-2 hour block. */
+  label: string;
+  /** Two-letter form for a 30-minute block. */
+  code: string;
+  tone: PositionTone;
+};
+
+const UNKNOWN_POSITION: PositionDisplay = {
+  name: "Unknown",
+  color: "#64748b",
+  label: "Unknown",
+  code: "??",
+  tone: "quiet",
+};
+
+const isUnavailable = (name: string) => /unavailab/i.test(name);
+
+/** Truncate on a word boundary where there is one. */
+const shortLabel = (name: string) => {
+  const trimmed = name.trim();
+  if (trimmed.length <= 10) return trimmed;
+
+  const cut = trimmed.slice(0, 10);
+  const boundary = cut.lastIndexOf(" ");
+  // Break on a space when there is a usable one; otherwise keep the full 10 chars
+  // rather than clipping further ("Enterprise…" reads, "Enterpri…" does not).
+  const base = boundary >= 5 ? cut.slice(0, boundary) : cut;
+  return `${base.replace(/[\s,./-]+$/, "")}…`;
+};
+
+/** Initials for a multi-word name, otherwise the first two letters. */
+const shortCode = (name: string) => {
+  const words = name
+    .trim()
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean);
+  if (words.length === 0) return "??";
+  if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase();
+  return words[0].slice(0, 2).toUpperCase();
+};
+
+/**
+ * The three tones are the point of the redesign: channel work reads loud, supporting
+ * work reads pale, and time an agent is not available recedes entirely -- so a glance
+ * down the grid shows where the coverage is rather than eleven equally loud colors.
+ *
+ * Tone comes from the admin-picked `Position["type"]`, with a name check for
+ * "unavailable" because it is conceptually a break but is not always typed as one.
+ */
+export const positionDisplay = (
+  position: Position | undefined
+): PositionDisplay => {
+  if (!position) return UNKNOWN_POSITION;
+
+  let tone: PositionTone;
+  if (isUnavailable(position.name) || position.type === "break") {
+    tone = "quiet";
+  } else if (position.type === "live channel" || position.type === "tickets") {
+    tone = "loud";
+  } else {
+    tone = "mid";
+  }
+
+  return {
+    name: position.name,
+    color: position.color,
+    label: shortLabel(position.name),
+    code: shortCode(position.name),
+    tone,
+  };
+};
+
+/** Hours an agent is scheduled today, excluding time marked unavailable. */
+export const scheduledHours = (
+  userShifts: Shift[] | undefined,
+  positionsById: Map<string, Position>,
+  selectedDate: Date
+) =>
+  (userShifts ?? []).reduce((total, shift) => {
+    const position = positionsById.get(String(shift.positionId));
+    if (position && isUnavailable(position.name)) return total;
+    const span = dayBounds(shift.startTime, shift.endTime, selectedDate);
+    return total + Math.max(0, span.end - span.start);
+  }, 0);

--- a/calendar-api-frontend/src/index.css
+++ b/calendar-api-frontend/src/index.css
@@ -51,6 +51,15 @@
     --radius: 0.5rem;
 
     --shiftmix: 203 72% 65%;
+
+    /* Schedule grid tokens (see src/components/ScheduleCalendar). --border is too
+       heavy for the 48 inner grid lines, and the grid needs a band a step off the
+       card plus a warn hue that isn't --destructive. */
+    --border-subtle: 214.3 31.8% 95.5%;
+    --band: 210 40% 98%;
+    --warn: 25 90% 48%;
+    --warn-bg: 33 100% 96%;
+    --me-tint: 217 60% 97%;
   }
 
   .dark {
@@ -83,6 +92,16 @@
     --ring: 212.7 26.8% 83.9%;
 
     --shiftmix: 240 100% 25%;
+
+    /* Dark background and card are the same slate in this theme, so --band has to
+       lift rather than recede to stay legible against both. */
+    --border-subtle: 217.2 32.6% 13%;
+    --band: 217.2 32.6% 10%;
+    --warn: 27 88% 58%;
+    /* Kept close to --card: a fully-missed day fills every one of the 48 cells, and
+       anything stronger turns the whole coverage row into a solid block. */
+    --warn-bg: 25 45% 11%;
+    --me-tint: 217.2 40% 12%;
   }
 }
 

--- a/calendar-api-frontend/src/pages/Settings/CoverageTargets/CoverageTargets.tsx
+++ b/calendar-api-frontend/src/pages/Settings/CoverageTargets/CoverageTargets.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useState } from "react";
+import { Info, Plus } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useUserSettings } from "@/providers/useUserSettings";
+import { CoverageMeter } from "@/types/coverageTypes";
+import { DEFAULT_COLORS } from "../ManagePositions/ManagePositions";
+import { emptyTargets } from "@/utils/coverageTargets";
+import { saveCoverageMeters } from "./coverageUtils";
+import MeterPanel from "./MeterPanel";
+
+/** Positions nobody expects a coverage row for, so they don't trip the notice. */
+const UNWATCHED_EXEMPT = /break|lunch|unavailab|meeting/i;
+
+/**
+ * The notice names the positions no meter counts. This instance has ~66 positions, so
+ * naming them all turns a one-line hint into a paragraph — list a handful and count
+ * the rest.
+ */
+const UNWATCHED_SHOWN = 8;
+
+/**
+ * Settings → Coverage Targets. Admin-only; the parent gates on `type === "admin"`
+ * and the API refuses non-admins independently.
+ *
+ * Every edit is local until Save, which replaces the whole list in one request —
+ * that is why the meters live in `useUserSettings` alongside `positionsToSync`:
+ * the page's existing unsaved-changes blocker diffs them against the saved baseline.
+ */
+export default function CoverageTargets() {
+  const {
+    allPositions,
+    coverageMeters,
+    originalCoverageMeters,
+    setCoverageMeters,
+    setOriginalCoverageMeters,
+  } = useUserSettings();
+
+  const [openMeterIds, setOpenMeterIds] = useState<string[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const isDirty =
+    JSON.stringify(coverageMeters) !== JSON.stringify(originalCoverageMeters);
+
+  /** position id -> the first meter counting it, for the picker's "in <meter>" note. */
+  const claimedBy = useMemo(() => {
+    const map = new Map<string, string>();
+    coverageMeters.forEach((meter) => {
+      meter.positionIds.forEach((id) => {
+        if (!map.has(String(id))) map.set(String(id), meter.name);
+      });
+    });
+    return map;
+  }, [coverageMeters]);
+
+  const unwatched = useMemo(() => {
+    const counted = new Set(
+      coverageMeters.flatMap((meter) => meter.positionIds.map(String))
+    );
+    return allPositions.filter(
+      (position) =>
+        !counted.has(String(position._id)) &&
+        !UNWATCHED_EXEMPT.test(position.name)
+    );
+  }, [allPositions, coverageMeters]);
+
+  const addMeter = () => {
+    // Temporary id: the server treats any non-ObjectId as "insert this one".
+    const _id = `new-${Date.now()}`;
+    const meter: CoverageMeter = {
+      _id,
+      name: `Meter ${coverageMeters.length + 1}`,
+      color: DEFAULT_COLORS[coverageMeters.length % DEFAULT_COLORS.length],
+      positionIds: [],
+      targets: emptyTargets(),
+    };
+    setCoverageMeters([...coverageMeters, meter]);
+    setOpenMeterIds([...openMeterIds, _id]);
+  };
+
+  const updateMeter = (updated: CoverageMeter) =>
+    setCoverageMeters(
+      coverageMeters.map((meter) =>
+        meter._id === updated._id ? updated : meter
+      )
+    );
+
+  const deleteMeter = (meterId: string) =>
+    setCoverageMeters(coverageMeters.filter((meter) => meter._id !== meterId));
+
+  const reset = () => setCoverageMeters(originalCoverageMeters);
+
+  const save = async () => {
+    const unnamed = coverageMeters.find((meter) => !meter.name.trim());
+    if (unnamed) {
+      toast.error("Every meter needs a name.");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const saved = await saveCoverageMeters(coverageMeters);
+      setCoverageMeters(saved);
+      setOriginalCoverageMeters(saved);
+      toast.success("Coverage targets saved.");
+    } catch (error) {
+      console.error("Error saving coverage targets:", error);
+      toast.error(
+        error instanceof Error ? error.message : "Failed to save coverage targets."
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Card className="scroll-mt-20 overflow-hidden" id="coverage-targets">
+      <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+        <div>
+          <CardTitle>Coverage Targets</CardTitle>
+          <CardDescription>
+            Define what the schedule watches. Each meter groups the positions
+            that count toward it and sets how many agents you want on it, hour by
+            hour. The schedule page flags any half hour that falls below the
+            target.
+          </CardDescription>
+        </div>
+        <Button className="shrink-0 gap-1.5" onClick={addMeter}>
+          <Plus size={16} />
+          Add Meter
+        </Button>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-3">
+        {coverageMeters.length === 0 && (
+          <div className="rounded-[9px] border border-dashed border-border px-3.5 py-6 text-center text-[12.5px] text-muted-foreground">
+            No coverage meters yet. Add one to start tracking coverage on the
+            schedule page.
+          </div>
+        )}
+
+        {coverageMeters.map((meter) => (
+          <MeterPanel
+            key={meter._id}
+            meter={meter}
+            positions={allPositions}
+            claimedBy={claimedBy}
+            isOpen={openMeterIds.includes(meter._id)}
+            onToggleOpen={() =>
+              setOpenMeterIds((prev) =>
+                prev.includes(meter._id)
+                  ? prev.filter((id) => id !== meter._id)
+                  : [...prev, meter._id]
+              )
+            }
+            onChange={updateMeter}
+            onDelete={() => deleteMeter(meter._id)}
+          />
+        ))}
+
+        {unwatched.length > 0 && (
+          <div className="flex items-start gap-2 rounded-[9px] border border-dashed border-border px-3.5 py-[11px] text-[12px] text-muted-foreground">
+            <Info size={14} className="mt-px shrink-0" />
+            <span>
+              {unwatched
+                .slice(0, UNWATCHED_SHOWN)
+                .map((position) => position.name)
+                .join(", ")}
+              {unwatched.length > UNWATCHED_SHOWN &&
+                ` and ${unwatched.length - UNWATCHED_SHOWN} more`}{" "}
+              {unwatched.length === 1 ? "is" : "are"} not counted by any meter,
+              so {unwatched.length === 1 ? "it won't" : "they won't"} appear in
+              the schedule&apos;s coverage rows.
+            </span>
+          </div>
+        )}
+      </CardContent>
+
+      <div className="flex items-center justify-between gap-4 border-t border-border bg-band px-[22px] py-3.5">
+        <span className="text-[12px] text-muted-foreground">
+          {isDirty ? "Unsaved changes" : "All changes saved"}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={reset} disabled={!isDirty || isSaving}>
+            Reset
+          </Button>
+          <Button onClick={save} disabled={!isDirty || isSaving}>
+            {isSaving ? "Saving…" : "Save changes"}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/calendar-api-frontend/src/pages/Settings/CoverageTargets/MeterPanel.tsx
+++ b/calendar-api-frontend/src/pages/Settings/CoverageTargets/MeterPanel.tsx
@@ -1,0 +1,228 @@
+import { ChevronRight, Trash2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { CoverageMeter } from "@/types/coverageTypes";
+import { Position } from "@/types/positionTypes";
+import { DEFAULT_COLORS } from "../ManagePositions/ManagePositions";
+import { utcTargetsToLocal, localTargetsToUtc } from "@/utils/coverageTargets";
+import PositionPicker from "./PositionPicker";
+import TargetGrid from "./TargetGrid";
+import { cn } from "@/lib/utils";
+
+type MeterPanelProps = {
+  meter: CoverageMeter;
+  positions: Position[];
+  claimedBy: Map<string, string>;
+  isOpen: boolean;
+  onToggleOpen: () => void;
+  onChange: (meter: CoverageMeter) => void;
+  onDelete: () => void;
+};
+
+const MeterPanel = ({
+  meter,
+  positions,
+  claimedBy,
+  isOpen,
+  onToggleOpen,
+  onChange,
+  onDelete,
+}: MeterPanelProps) => {
+  const positionsById = new Map(positions.map((p) => [String(p._id), p]));
+  // A position deleted in Manage Positions leaves its id behind on the meter; drop
+  // those here rather than rendering a chip for something that no longer exists.
+  const chips = meter.positionIds
+    .map((id) => positionsById.get(String(id)))
+    .filter((p): p is Position => Boolean(p));
+
+  const summary =
+    chips.length === 0
+      ? "no positions assigned yet"
+      : `${chips.length} position${chips.length === 1 ? "" : "s"} · ${chips
+          .map((p) => p.name)
+          .join(", ")}`;
+
+  const togglePosition = (positionId: string) => {
+    const has = meter.positionIds.some((id) => String(id) === positionId);
+    onChange({
+      ...meter,
+      positionIds: has
+        ? meter.positionIds.filter((id) => String(id) !== positionId)
+        : [...meter.positionIds, positionId],
+    });
+  };
+
+  return (
+    <div
+      className={cn(
+        "rounded-[10px] border border-border",
+        isOpen ? "bg-card" : "bg-band"
+      )}
+    >
+      <div className="relative flex items-center gap-3 p-4">
+        <button
+          type="button"
+          aria-label={isOpen ? "Collapse meter" : "Expand meter"}
+          className="flex h-[22px] w-[22px] items-center justify-center text-muted-foreground"
+          onClick={onToggleOpen}
+        >
+          <ChevronRight
+            size={16}
+            className={cn("transition-transform duration-150", isOpen && "rotate-90")}
+          />
+        </button>
+
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Meter color"
+              className="h-[15px] w-[15px] shrink-0 cursor-pointer rounded-[5px] border border-black/20"
+              style={{ backgroundColor: meter.color }}
+            />
+          </PopoverTrigger>
+          <PopoverContent className="w-auto rounded-[10px] p-3" align="start">
+            <div className="mb-2 text-[12px] font-semibold">Meter color</div>
+            <div className="flex gap-2">
+              {DEFAULT_COLORS.map((color) => (
+                <button
+                  key={color}
+                  type="button"
+                  aria-label={color}
+                  className={cn(
+                    "h-[30px] w-[30px] rounded-full",
+                    meter.color.toLowerCase() === color.toLowerCase() &&
+                      "ring-2 ring-foreground ring-offset-2 ring-offset-background"
+                  )}
+                  style={{ backgroundColor: color }}
+                  onClick={() => onChange({ ...meter, color })}
+                />
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+
+        <Input
+          value={meter.name}
+          aria-label="Meter name"
+          className="h-8 w-[220px] rounded-[7px] border-transparent bg-transparent text-[14px] font-semibold"
+          onChange={(e) => onChange({ ...meter, name: e.target.value })}
+        />
+
+        <div className="min-w-0 flex-1 truncate text-[12px] text-muted-foreground">
+          {summary}
+        </div>
+
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              aria-label="Delete meter"
+              className="h-[30px] w-[30px] shrink-0"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete meter</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete &quot;{meter.name}&quot;? Its
+                coverage row will stop appearing on the schedule page once you
+                save.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={onDelete}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+
+      {isOpen && (
+        <div className="flex flex-col gap-5 border-t border-border px-4 py-[18px]">
+          <div className="flex flex-col gap-2">
+            <div>
+              <div className="text-[12.5px] font-semibold">
+                Positions counted
+              </div>
+              <div className="text-[11.5px] text-muted-foreground">
+                shifts on these positions add to this meter
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {chips.length === 0 && (
+                <span className="text-[12px] text-muted-foreground">
+                  No positions yet
+                </span>
+              )}
+              {chips.map((position) => (
+                <span
+                  key={String(position._id)}
+                  className="flex h-[30px] items-center gap-2 rounded-lg border py-0 pl-[11px] pr-1.5 text-[12px] font-semibold"
+                  style={{
+                    borderColor: position.color,
+                    backgroundColor: `color-mix(in srgb, ${position.color} 14%, transparent)`,
+                  }}
+                >
+                  <span
+                    className="h-2 w-2 rounded-full"
+                    style={{ backgroundColor: position.color }}
+                  />
+                  {position.name}
+                  <button
+                    type="button"
+                    aria-label={`Remove ${position.name}`}
+                    className="flex h-[18px] w-[18px] items-center justify-center rounded text-muted-foreground hover:bg-foreground/10"
+                    onClick={() => togglePosition(String(position._id))}
+                  >
+                    <X size={12} />
+                  </button>
+                </span>
+              ))}
+              <PositionPicker
+                positions={positions}
+                selectedIds={meter.positionIds.map(String)}
+                claimedBy={claimedBy}
+                onToggle={togglePosition}
+              />
+            </div>
+          </div>
+
+          <TargetGrid
+            local={utcTargetsToLocal(meter.targets)}
+            color={meter.color}
+            onChange={(local) =>
+              onChange({ ...meter, targets: localTargetsToUtc(local) })
+            }
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MeterPanel;

--- a/calendar-api-frontend/src/pages/Settings/CoverageTargets/PositionPicker.tsx
+++ b/calendar-api-frontend/src/pages/Settings/CoverageTargets/PositionPicker.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { Check, Plus } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Position } from "@/types/positionTypes";
+import { cn } from "@/lib/utils";
+
+type PositionPickerProps = {
+  positions: Position[];
+  selectedIds: string[];
+  /** Position id -> the name of another meter already counting it, for the hint. */
+  claimedBy: Map<string, string>;
+  onToggle: (positionId: string) => void;
+};
+
+/**
+ * Searchable multi-select for a meter's positions.
+ *
+ * A position may belong to more than one meter — the "in <meter>" note is a heads-up,
+ * not a lock, since the same shift can legitimately count toward two things.
+ */
+const PositionPicker = ({
+  positions,
+  selectedIds,
+  claimedBy,
+  onToggle,
+}: PositionPickerProps) => {
+  const [open, setOpen] = useState(false);
+  const selected = new Set(selectedIds);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex h-[30px] items-center gap-1.5 rounded-lg border border-dashed border-border px-2.5 text-[12px] text-muted-foreground hover:bg-muted"
+        >
+          <Plus size={13} />
+          Add position
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[400px] rounded-[10px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search positions…" className="text-[13px]" />
+          <CommandList className="max-h-[224px]">
+            <CommandEmpty>No position matches that search.</CommandEmpty>
+            <CommandGroup className="p-1.5">
+              {positions.map((position) => {
+                const id = String(position._id);
+                const isSelected = selected.has(id);
+                const otherMeter = claimedBy.get(id);
+                return (
+                  <CommandItem
+                    key={id}
+                    value={position.name}
+                    // Keep the list open so several can be picked in one go.
+                    onSelect={() => onToggle(id)}
+                    className={cn(
+                      "gap-[9px] rounded-[7px] px-2.5 py-2",
+                      isSelected && "bg-muted"
+                    )}
+                  >
+                    <span
+                      className="h-[9px] w-[9px] shrink-0 rounded-full"
+                      style={{ backgroundColor: position.color }}
+                    />
+                    <span
+                      className={cn(
+                        "truncate text-[12.5px]",
+                        isSelected && "font-semibold"
+                      )}
+                    >
+                      {position.name}
+                    </span>
+                    {otherMeter && !isSelected && (
+                      <span className="ml-auto shrink-0 text-[10.5px] text-muted-foreground">
+                        in {otherMeter}
+                      </span>
+                    )}
+                    {isSelected && (
+                      <Check className="ml-auto h-4 w-4 shrink-0 text-primary" />
+                    )}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default PositionPicker;

--- a/calendar-api-frontend/src/pages/Settings/CoverageTargets/TargetGrid.tsx
+++ b/calendar-api-frontend/src/pages/Settings/CoverageTargets/TargetGrid.tsx
@@ -1,0 +1,172 @@
+import { Button } from "@/components/ui/button";
+import {
+  DAY_LABELS,
+  HOURS_PER_DAY,
+  MAX_TARGET,
+  isWeekend,
+  localZoneLabel,
+  summarizeTargets,
+} from "@/utils/coverageTargets";
+import { cn } from "@/lib/utils";
+
+type TargetGridProps = {
+  /** Targets in the admin's local time — the parent converts to/from UTC. */
+  local: number[][];
+  color: string;
+  onChange: (local: number[][]) => void;
+};
+
+const MONDAY = 1;
+const WEEKDAYS = [1, 2, 3, 4, 5];
+
+/**
+ * The per-hour target editor: 7 rows × 24 hours, Sunday-first to match the stored
+ * day index (and `User.workHours.dayOfWeek`) rather than the design mock's Mon-first
+ * grid — one day convention across agendo is worth more than matching the mock here.
+ *
+ * Columns are the viewer's *local* hours. Storage is UTC, so an admin in another
+ * timezone editing the same meter sees the same absolute targets on their own clock;
+ * the caption under the grid names the zone so that is never implicit.
+ */
+const TargetGrid = ({ local, color, onChange }: TargetGridProps) => {
+  const { total, peak } = summarizeTargets(local);
+
+  const setCell = (day: number, hour: number, value: number) => {
+    const next = local.map((row) => [...row]);
+    next[day][hour] = Math.min(MAX_TARGET, Math.max(0, value));
+    onChange(next);
+  };
+
+  const copyMondayToWeekdays = () => {
+    const next = local.map((row) => [...row]);
+    WEEKDAYS.forEach((day) => {
+      next[day] = [...local[MONDAY]];
+    });
+    onChange(next);
+  };
+
+  const clear = () =>
+    onChange(local.map((row) => row.map(() => 0)));
+
+  /** Fill strength tracks the value against the meter's own peak. */
+  const cellStyle = (value: number) => {
+    if (value === 0) return undefined;
+    const mix = 18 + (value / Math.max(1, peak)) * 62;
+    return {
+      backgroundColor: `color-mix(in srgb, ${color} ${mix}%, hsl(var(--card)))`,
+      color: mix > 60 ? "#ffffff" : undefined,
+    };
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-3">
+        <div>
+          <div className="text-[12.5px] font-semibold">
+            Agents needed per hour
+          </div>
+          <div className="text-[11.5px] text-muted-foreground">
+            click to raise, right-click to lower
+          </div>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="h-[26px] rounded-[7px] px-2.5 text-[11.5px]"
+            onClick={copyMondayToWeekdays}
+          >
+            Copy Mon → weekdays
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-[26px] rounded-[7px] px-2.5 text-[11.5px]"
+            onClick={clear}
+          >
+            Clear
+          </Button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-[9px] border border-border">
+        <div
+          className="min-w-[724px]"
+          style={{
+            display: "grid",
+            gridTemplateColumns: `52px repeat(${HOURS_PER_DAY}, minmax(28px, 1fr))`,
+          }}
+        >
+          <div className="border-b border-border bg-card" />
+          {Array.from({ length: HOURS_PER_DAY }, (_, hour) => (
+            <div
+              key={`head-${hour}`}
+              className="border-b border-border py-[7px] text-center text-[10px] font-semibold tabular-nums text-muted-foreground"
+            >
+              {String(hour).padStart(2, "0")}
+            </div>
+          ))}
+
+          {DAY_LABELS.map((label, day) => (
+            <div key={label} className="contents">
+              <div
+                className={cn(
+                  "flex items-center px-2.5 text-[11px] font-semibold",
+                  day < 6 && "border-b border-border",
+                  isWeekend(day) && "bg-band text-muted-foreground"
+                )}
+              >
+                {label}
+              </div>
+              {Array.from({ length: HOURS_PER_DAY }, (_, hour) => {
+                const value = local[day]?.[hour] ?? 0;
+                return (
+                  <button
+                    key={`${label}-${hour}`}
+                    type="button"
+                    aria-label={`${label} ${String(hour).padStart(2, "0")}:00 — ${value} agents`}
+                    title={`${label} ${String(hour).padStart(2, "0")}:00 — ${value} agents`}
+                    className={cn(
+                      "h-[28px] border-l border-border-subtle text-[11px] font-semibold tabular-nums",
+                      day < 6 && "border-b border-border",
+                      value === 0 &&
+                        (isWeekend(day) ? "bg-band" : "bg-card") +
+                          " text-muted-foreground/40"
+                    )}
+                    style={cellStyle(value)}
+                    onClick={() => setCell(day, hour, value + 1)}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      setCell(day, hour, value - 1);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "ArrowUp" || e.key === "+") {
+                        e.preventDefault();
+                        setCell(day, hour, value + 1);
+                      } else if (e.key === "ArrowDown" || e.key === "-") {
+                        e.preventDefault();
+                        setCell(day, hour, value - 1);
+                      } else if (/^[0-8]$/.test(e.key)) {
+                        e.preventDefault();
+                        setCell(day, hour, Number(e.key));
+                      }
+                    }}
+                  >
+                    {value === 0 ? "·" : value}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="text-[11.5px] text-muted-foreground">
+        {total} agent-hours per week · peak {peak} at once · times shown in your
+        local zone ({localZoneLabel()})
+      </div>
+    </div>
+  );
+};
+
+export default TargetGrid;

--- a/calendar-api-frontend/src/pages/Settings/CoverageTargets/coverageUtils.ts
+++ b/calendar-api-frontend/src/pages/Settings/CoverageTargets/coverageUtils.ts
@@ -1,0 +1,58 @@
+import { CoverageMeter } from "@/types/coverageTypes";
+import { normalizeTargets } from "@/utils/coverageTargets";
+
+/**
+ * Coverage meters are admin-only on the API too (both routes are behind adminOnly),
+ * so a non-admin gets a 403 here — callers must gate on `type === "admin"` rather
+ * than relying on an empty list coming back.
+ */
+
+const asMeter = (raw: CoverageMeter): CoverageMeter => ({
+  ...raw,
+  positionIds: (raw.positionIds ?? []).map(String),
+  targets: normalizeTargets(raw.targets),
+});
+
+export async function getCoverageMeters(): Promise<CoverageMeter[]> {
+  const response = await fetch("/api/coverage-meter", {
+    method: "GET",
+    mode: "cors",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!response.ok) throw new Error("Failed to fetch coverage meters");
+  const data = (await response.json()) as CoverageMeter[];
+  return data.map(asMeter);
+}
+
+/**
+ * Replace-all save: the settings card batches every edit behind one "Save changes"
+ * button, so the whole list goes up at once and the server reconciles deletes.
+ * Locally-created meters carry a temporary `_id`, which the server ignores.
+ */
+export async function saveCoverageMeters(
+  meters: CoverageMeter[],
+): Promise<CoverageMeter[]> {
+  const response = await fetch("/api/coverage-meter", {
+    method: "PUT",
+    mode: "cors",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      meters: meters.map((meter, index) => ({
+        _id: meter._id,
+        name: meter.name.trim(),
+        color: meter.color,
+        positionIds: meter.positionIds,
+        targets: meter.targets,
+        order: index,
+      })),
+    }),
+  });
+  if (!response.ok) {
+    const detail = await response.json().catch(() => null);
+    throw new Error(detail?.message || "Failed to save coverage meters");
+  }
+  const data = (await response.json()) as CoverageMeter[];
+  return data.map(asMeter);
+}

--- a/calendar-api-frontend/src/pages/Settings/ManagePositions/ManagePositions.tsx
+++ b/calendar-api-frontend/src/pages/Settings/ManagePositions/ManagePositions.tsx
@@ -76,7 +76,8 @@ const POSITION_TYPES = [
   "training",
 ];
 
-const DEFAULT_COLORS = [
+/** Shared with Coverage Targets so meters and positions draw from one palette. */
+export const DEFAULT_COLORS = [
   "#3B82F6",
   "#EF4444",
   "#10B981",

--- a/calendar-api-frontend/src/pages/Settings/Settings.tsx
+++ b/calendar-api-frontend/src/pages/Settings/Settings.tsx
@@ -7,12 +7,15 @@ import ProceedWithUnsavedChanges from "@/components/modals/ProceedWithUnsavedCha
 import GenerateAPIToken from "./GenerateAPIToken/GenerateAPIToken.tsx";
 import ManageLocations from "./ManageLocations/ManageLocations.tsx";
 import ManagePositions from "./ManagePositions/ManagePositions.tsx";
+import CoverageTargets from "./CoverageTargets/CoverageTargets.tsx";
 // import { useIntersectionObserver } from "../../hooks/useIntersectionObserver.tsx";
 
 export default function Settings() {
   const {
     positionsToSync,
     originalPositionsToSync,
+    coverageMeters,
+    originalCoverageMeters,
     setUnsavedChangesAlertOpen,
     type,
   } = useUserSettings();
@@ -20,7 +23,8 @@ export default function Settings() {
   const hasUnsavedChanges = () => {
     return (
       JSON.stringify(positionsToSync) !==
-      JSON.stringify(originalPositionsToSync)
+        JSON.stringify(originalPositionsToSync) ||
+      JSON.stringify(coverageMeters) !== JSON.stringify(originalCoverageMeters)
     );
   };
 
@@ -35,7 +39,12 @@ export default function Settings() {
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, [positionsToSync, originalPositionsToSync]);
+  }, [
+    positionsToSync,
+    originalPositionsToSync,
+    coverageMeters,
+    originalCoverageMeters,
+  ]);
 
   const blocker: Blocker = useBlocker(({ currentLocation, nextLocation }) => {
     if (
@@ -91,6 +100,15 @@ export default function Settings() {
             >
               Manage Locations
             </a>
+            {/* Coverage targets are admin-only, so the link is too. */}
+            {type === "admin" && (
+              <a
+                href="#coverage-targets"
+                className={"font-semibold text-primary"}
+              >
+                Coverage targets
+              </a>
+            )}
           </nav>
           <div className="grid gap-6" id="settings-wrapper">
             {/* <GoogleIntegration></GoogleIntegration> */}
@@ -100,6 +118,7 @@ export default function Settings() {
                 <GenerateAPIToken />
                 <ManageLocations />
                 <ManagePositions />
+                <CoverageTargets />
               </div>
             )}
           </div>

--- a/calendar-api-frontend/src/providers/user-settings-provider.tsx
+++ b/calendar-api-frontend/src/providers/user-settings-provider.tsx
@@ -1,6 +1,8 @@
 import { createContext, useState, useEffect } from "react";
 import { Position } from "@/types/positionTypes.ts";
 import { UserSafeInfo } from "@/types/userTypes";
+import { CoverageMeter } from "@/types/coverageTypes";
+import { getCoverageMeters } from "@/pages/Settings/CoverageTargets/coverageUtils";
 import { useAuth } from "@clerk/clerk-react"; // Assuming you are using Clerk's useAuth hook
 
 type UserSettingsProviderProps = {
@@ -19,6 +21,8 @@ type UserSettingsProviderState = {
   allUsers: UserSafeInfo[];
   positionsToSync: Position[];
   originalPositionsToSync: Position[];
+  coverageMeters: CoverageMeter[];
+  originalCoverageMeters: CoverageMeter[];
   defaultEventColorId: string | null;
   isGoogleAuthenticated: boolean;
   userGoogleInfo: string;
@@ -33,6 +37,8 @@ type UserSettingsProviderState = {
   setAllUsers: (value: UserSafeInfo[]) => void;
   setPositionsToSync: (value: Position[]) => void;
   setOriginalPositionsToSync: (value: Position[]) => void;
+  setCoverageMeters: (value: CoverageMeter[]) => void;
+  setOriginalCoverageMeters: (value: CoverageMeter[]) => void;
   setDefaultEventColorId: (value: string | null) => void;
   setIsGoogleAuthenticated: (value: boolean) => void;
   setUserGoogleInfo: (value: string) => void;
@@ -56,6 +62,10 @@ export function UserSettingsProvider({ children }: UserSettingsProviderProps) {
   const [positionsToSync, setPositionsToSync] = useState<Position[]>([]);
   const [originalPositionsToSync, setOriginalPositionsToSync] = useState<
     Position[]
+  >([]);
+  const [coverageMeters, setCoverageMeters] = useState<CoverageMeter[]>([]);
+  const [originalCoverageMeters, setOriginalCoverageMeters] = useState<
+    CoverageMeter[]
   >([]);
   const [defaultEventColorId, setDefaultEventColorId] = useState<string | null>(
     null
@@ -134,6 +144,25 @@ export function UserSettingsProvider({ children }: UserSettingsProviderProps) {
     }
   }, [isSignedIn]);
 
+  // Coverage meters are admin-only on both ends, and `type` only lands once
+  // /api/user/info resolves — so this can't ride along with the fetches above.
+  // `originalCoverageMeters` is the baseline the Settings card diffs against for
+  // its dirty state and Reset, mirroring positionsToSync.
+  useEffect(() => {
+    if (!userInfoLoaded || type !== "admin") return;
+
+    const loadCoverageMeters = async () => {
+      try {
+        const meters = await getCoverageMeters();
+        setCoverageMeters(meters);
+        setOriginalCoverageMeters(meters);
+      } catch (e) {
+        console.error("Failed to get coverage meters", e);
+      }
+    };
+    loadCoverageMeters();
+  }, [userInfoLoaded, type]);
+
   const value = {
     firstName,
     lastName,
@@ -146,6 +175,8 @@ export function UserSettingsProvider({ children }: UserSettingsProviderProps) {
     allUsers,
     positionsToSync,
     originalPositionsToSync,
+    coverageMeters,
+    originalCoverageMeters,
     defaultEventColorId,
     isGoogleAuthenticated,
     userGoogleInfo,
@@ -160,6 +191,8 @@ export function UserSettingsProvider({ children }: UserSettingsProviderProps) {
     setAllUsers,
     setPositionsToSync,
     setOriginalPositionsToSync,
+    setCoverageMeters,
+    setOriginalCoverageMeters,
     setDefaultEventColorId,
     setIsGoogleAuthenticated,
     setUserGoogleInfo,

--- a/calendar-api-frontend/src/types/coverageTypes.ts
+++ b/calendar-api-frontend/src/types/coverageTypes.ts
@@ -1,0 +1,22 @@
+/** A named, colored group of positions with an hourly headcount target per weekday.
+ *
+ * The schedule page renders one coverage row per meter and flags any half hour where
+ * fewer agents are scheduled than the target asks for. Admin-only, end to end.
+ *
+ * `positionIds` are `Position._id` values — the same id space as `Shift.positionId`,
+ * not the Sling id in `Position.positionId`.
+ *
+ * `targets[d][s]` is **UTC**, Sunday-first: `d` is `Date#getUTCDay()`, `s` is a
+ * half-hour slot 0..47. Agendo is used across timezones, so a target is stored as an
+ * absolute weekly instant rather than a wall-clock label; clients convert to their
+ * own local time for display. See `src/utils/coverageTargets.ts` — including why the
+ * slots are half-hourly even though the settings grid is hourly.
+ */
+export type CoverageMeter = {
+  _id: string;
+  name: string;
+  color: string;
+  positionIds: string[];
+  targets: number[][];
+  order?: number;
+};

--- a/calendar-api-frontend/src/utils/addShiftToSchedule.tsx
+++ b/calendar-api-frontend/src/utils/addShiftToSchedule.tsx
@@ -2,6 +2,18 @@
 import { CalendarUser } from "@/types/gCalendarTypes";
 import { Shift, SortedCalendar } from "@/types/shiftTypes";
 
+const byStartTime = (a: Shift, b: Shift) =>
+  new Date(a.startTime).getTime() - new Date(b.startTime).getTime();
+
+/**
+ * Splice a newly created shift into the schedule without refetching the day.
+ *
+ * Every level is replaced rather than mutated. This used to `push` onto
+ * `shifts[userId]` and only spread the outer object, so the agent's own array kept
+ * its identity — the schedule grid memoises each agent's lane packing on that array,
+ * and a second shift for the same agent would not appear until a reload (the first
+ * one did, because a missing key allocated a fresh array).
+ */
 export function addShiftToSchedule(
   newShift: Shift,
   shifts: SortedCalendar,
@@ -11,29 +23,25 @@ export function addShiftToSchedule(
 ) {
   const userId = newShift.userId;
 
-  if (!shifts[userId]) {
-    shifts[userId] = [];
-  }
-
-  shifts[userId].push(newShift);
-
-  shifts[userId].sort(
-    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
-  );
-
-  setShifts({ ...shifts });
+  setShifts({
+    ...shifts,
+    [userId]: [...(shifts[userId] ?? []), newShift].sort(byStartTime),
+  });
 
   if (newShift.isSynced) {
-    const userEvents = events.find((event) => event.userId === userId)?.events;
-    if (userEvents) {
-      userEvents.push(newShift.syncedEvent);
-      userEvents.sort((a, b) => {
-        return (
-          new Date(a.start.dateTime).getTime() -
-          new Date(b.start.dateTime).getTime()
-        );
-      });
-    }
-    setEvents([...events]);
+    setEvents(
+      events.map((calendarUser) =>
+        calendarUser.userId === userId
+          ? {
+              ...calendarUser,
+              events: [...calendarUser.events, newShift.syncedEvent].sort(
+                (a, b) =>
+                  new Date(a.start.dateTime).getTime() -
+                  new Date(b.start.dateTime).getTime()
+              ),
+            }
+          : calendarUser
+      )
+    );
   }
 }

--- a/calendar-api-frontend/src/utils/coverageTargets.ts
+++ b/calendar-api-frontend/src/utils/coverageTargets.ts
@@ -1,0 +1,161 @@
+import { CoverageMeter } from "@/types/coverageTypes";
+
+/**
+ * Coverage targets are stored in UTC — `targets[utcDay][utcHalfHourSlot]`, 7 × 48,
+ * Sunday-first. Agendo is used across timezones, so a target has to be an absolute
+ * weekly instant: "3 agents at 09:00" set by an admin in UTC−03:00 is the same moment
+ * as 14:00 for a viewer in UTC+02:00, and both should see it on their own clock.
+ *
+ * Storage is *half-hourly* even though the editor is hourly, because whole-hour UTC
+ * buckets cannot represent an hour in a half-hour zone: in UTC+05:30, local 09:00 is
+ * UTC 03:30 and local 09:30 is UTC 04:00, so an hourly grid silently shifts the whole
+ * target window by 30 minutes. Half-hour slots make the mapping exact for every :00
+ * and :30 offset, and they line up with the schedule grid's own 48 slots. (:45 zones
+ * — Chatham, Kathmandu — are still off by 15 minutes; 15-minute storage would be the
+ * next step if that ever matters.)
+ *
+ * This module is the only place that knows about the convention. The schedule page
+ * reads a target for a slot instant; the settings grid edits a local *hourly* grid and
+ * converts on load/save.
+ */
+
+export const DAYS_PER_WEEK = 7;
+/** Columns in the editor — local hours. */
+export const HOURS_PER_DAY = 24;
+/** Columns in storage — UTC half hours. */
+export const SLOTS_PER_DAY = 48;
+export const MAX_TARGET = 8;
+
+/** Day labels for the settings grid, Sunday-first to match the stored day index. */
+export const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/** Sunday and Saturday — shaded in the settings grid. */
+export const isWeekend = (day: number) => day === 0 || day === 6;
+
+const grid = (width: number): number[][] =>
+  Array.from({ length: DAYS_PER_WEEK }, () =>
+    Array.from({ length: width }, () => 0),
+  );
+
+/** A blank stored (UTC, half-hourly) grid. */
+export const emptyTargets = (): number[][] => grid(SLOTS_PER_DAY);
+
+/** A blank editor (local, hourly) grid. */
+export const emptyLocalTargets = (): number[][] => grid(HOURS_PER_DAY);
+
+/** Coerce anything the API hands back into a well-formed 7 × 48 grid. */
+export const normalizeTargets = (targets: unknown): number[][] => {
+  const out = emptyTargets();
+  if (!Array.isArray(targets)) return out;
+  for (let day = 0; day < DAYS_PER_WEEK; day++) {
+    const row = targets[day];
+    if (!Array.isArray(row)) continue;
+    for (let slot = 0; slot < SLOTS_PER_DAY; slot++) {
+      const value = Number(row[slot]);
+      if (Number.isFinite(value)) {
+        out[day][slot] = Math.min(MAX_TARGET, Math.max(0, Math.round(value)));
+      }
+    }
+  }
+  return out;
+};
+
+/** Half-hour slot index (0..47) of an instant, in UTC. */
+const utcSlot = (instant: Date) =>
+  instant.getUTCHours() * 2 + (instant.getUTCMinutes() >= 30 ? 1 : 0);
+
+/**
+ * The target in force at an absolute instant.
+ *
+ * Resolved from the instant itself rather than from arithmetic on a day/hour label,
+ * which is what makes this DST-correct: a local day's 48 half-hour slots can straddle
+ * two UTC days, and this simply follows them across.
+ */
+export const targetAt = (meter: CoverageMeter, instant: Date): number =>
+  meter.targets?.[instant.getUTCDay()]?.[utcSlot(instant)] ?? 0;
+
+/** Local midnight on the Sunday of the week containing `reference`. */
+const startOfLocalWeek = (reference: Date): Date => {
+  const start = new Date(reference);
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - start.getDay());
+  return start;
+};
+
+/**
+ * Walk the 336 half hours of a reference week, handing each one its local (day, hour)
+ * and the matching UTC (day, slot). Both conversions below are the same walk, read in
+ * opposite directions.
+ *
+ * The reference week is the one containing today. Across a DST boundary a local hour
+ * can be skipped or repeated, so a cell or two in that specific week may shift by an
+ * hour on a round trip; every other week is an exact bijection.
+ */
+const eachHalfHour = (
+  visit: (
+    localDay: number,
+    localHour: number,
+    utcDay: number,
+    slot: number,
+  ) => void,
+  reference = new Date(),
+) => {
+  const weekStart = startOfLocalWeek(reference);
+  for (let day = 0; day < DAYS_PER_WEEK; day++) {
+    for (let hour = 0; hour < HOURS_PER_DAY; hour++) {
+      for (const minute of [0, 30]) {
+        const instant = new Date(weekStart);
+        instant.setDate(weekStart.getDate() + day);
+        instant.setHours(hour, minute, 0, 0);
+        visit(day, hour, instant.getUTCDay(), utcSlot(instant));
+      }
+    }
+  }
+};
+
+/** Stored UTC grid → the hourly grid the editor shows, in the viewer's local time. */
+export const utcTargetsToLocal = (targets: number[][]): number[][] => {
+  const local = emptyLocalTargets();
+  // Both half hours of a local hour carry the same value; if they ever disagree
+  // (hand-edited data), show the larger so a target is never under-reported.
+  eachHalfHour((day, hour, utcDay, slot) => {
+    local[day][hour] = Math.max(
+      local[day][hour],
+      targets?.[utcDay]?.[slot] ?? 0,
+    );
+  });
+  return local;
+};
+
+/** Editor's local hourly grid → the UTC half-hourly grid that gets persisted. */
+export const localTargetsToUtc = (local: number[][]): number[][] => {
+  const targets = emptyTargets();
+  eachHalfHour((day, hour, utcDay, slot) => {
+    targets[utcDay][slot] = local?.[day]?.[hour] ?? 0;
+  });
+  return targets;
+};
+
+/** e.g. `UTC−03:00`. Shown under the settings grid so the zone is never implicit. */
+export const localZoneLabel = (reference = new Date()): string => {
+  // getTimezoneOffset is minutes *behind* UTC, so the sign is inverted.
+  const offsetMinutes = -reference.getTimezoneOffset();
+  const sign = offsetMinutes < 0 ? "−" : "+";
+  const absolute = Math.abs(offsetMinutes);
+  const hours = String(Math.floor(absolute / 60)).padStart(2, "0");
+  const minutes = String(absolute % 60).padStart(2, "0");
+  return `UTC${sign}${hours}:${minutes}`;
+};
+
+/** `168 agent-hours per week · peak 3 at once` for the grid footer. */
+export const summarizeTargets = (local: number[][]) => {
+  let total = 0;
+  let peak = 0;
+  for (const row of local) {
+    for (const value of row) {
+      total += value;
+      if (value > peak) peak = value;
+    }
+  }
+  return { total, peak };
+};

--- a/calendar-api-frontend/tailwind.config.js
+++ b/calendar-api-frontend/tailwind.config.js
@@ -55,6 +55,15 @@ module.exports = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        // Schedule grid tokens — see the matching block in src/index.css.
+        // `border-subtle` is a color, so the border utility is `border-border-subtle`.
+        "border-subtle": "hsl(var(--border-subtle))",
+        band: "hsl(var(--band))",
+        warn: {
+          DEFAULT: "hsl(var(--warn))",
+          bg: "hsl(var(--warn-bg))",
+        },
+        "me-tint": "hsl(var(--me-tint))",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
Rebuilds `/app/schedule` on the chosen **"Dense"** layout from the design handoff, and adds a **Coverage Targets** card to Settings where admins define what the schedule watches.

`/app/sling-schedule` is untouched.

## Schedule grid

Fixes the three problems the design work set out to solve:

- **One scroll container.** A sticky 252px agent column over a 48-column half-hour track, replacing the per-row `overflow-x: auto` that let the hour ruler and every agent row scroll independently of each other.
- **Overlaps stack.** Greedy lane packing for both shifts and Google Calendar events, replacing `calculateShiftOverlapAmount` — which only compared *adjacent* pairs, so it missed a shift overlapping a non-neighbour, and produced ragged `rem`-computed row heights. Row height now falls out of the lane count.
- **Short blocks read.** Content degrades with width: time + label → label → tight label → two-letter code. The time goes first because the ruler already says when. Full name and time stay on hover.

Plus: tone driven off `Position.type` (channel work loud, supporting work pale, breaks quiet), a ticking now line, the gcal under-lane, a legend footer, and skeletons sized to the final row height so the layout no longer jumps.

## Coverage targets — admin only

A meter is named, colored, owns a set of positions and a per-hour target for each day. The schedule renders one row per meter and flags every half hour below target. Gated on `type === "admin"` on the client *and* behind `adminOnly` on both API routes, reads included.

Edits batch behind a single **Save changes**, so persistence is a bulk replace-all `PUT /coverage-meter` rather than per-item CRUD.

### Timezone model

Agendo is used across timezones, so a target is stored as an **absolute weekly instant**, never a wall-clock label: `targets[utcDay][halfHourSlot]`, 7 × 48, Sunday-first (matching `getUTCDay()` and the existing `User.workHours.dayOfWeek`). Admins edit an hourly grid in their own local time; the card converts on load and save and names the zone underneath.

Storage is **half-hourly rather than hourly** because whole UTC hours cannot represent a local hour in a half-hour zone — in UTC+05:30, local 09:00 is UTC 03:30 and local 09:30 is UTC 04:00, so an hourly grid silently shifted every target window by 30 minutes. Caught by a harness before it shipped:

```
--- zone: UTC+05:30 (TZ=Asia/Kolkata) ---
FAIL  target reads back at local Wed 09:30
        expected 4   actual 0
```

Half-hour slots make the mapping exact for every `:00` and `:30` offset and line up with the schedule's own 48 columns. The schedule resolves each slot from its absolute instant, so it stays correct when a local day straddles two UTC days and across DST.

Known limitation: `:45` zones (Chatham, Kathmandu) are still off by 15 minutes. 15-minute storage would be the fix if that ever matters.

## Included bug fix

`addShiftToSchedule` did `shifts[userId].push(...)` and only spread the outer object, so the agent's own array kept its identity. With the new memoised lane packing that meant a *second* shift for an agent stayed invisible until a reload (the first worked, because a missing key allocated a fresh array). Both levels are now replaced immutably; the same fix is applied to the drag-and-drop handler in `EmptySlot`, which additionally filters the target array so dropping a shift back on the same agent can't duplicate it.

## Deliberate deviations from the mock

- **Target grid is Sunday-first**, not the mock's Monday-first — one day-index convention across agendo is worth more than matching the design file.
- Position `label` / `code` are derived in the frontend rather than added to the `Position` schema.
- The **New shift** button renders dark, not blue: this repo's `--primary` is near-black, and the handoff says prefer the existing token.
- The unwatched-positions notice caps at 8 names + "and N more" — the mock assumed ~11 positions, this instance has 66.

## Verification

- `tsc && vite build` clean; ESLint clean on every touched file (the pre-existing errors in `BulkDeleteBtn.tsx` are untouched).
- Logic harness across 8 timezones: UTC↔local round trip, target resolution, lane packing, coverage counting, summary text, tone/label/code, overnight clipping.
- The state-mutation fix has a control run proving the old implementation fails the two checks that matter.
- Driven in the browser: grid alignment measured against the ruler, coverage bar/tick geometry checked against the DOM, all four block width modes, lane stacking, overnight clipping, scheduled-hours totals, the Settings card, and shift creation appearing without a reload.

**Not yet exercised:** bulk-select rendering, Duplicate day, and the non-admin view. Note also that `adminOnly` is a no-op when `NODE_ENV=development`, so the API gate can't be tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
