### PR TITLE
fix: clerk new-user webhook timed out on every signup

### DIFF
--- a/calendar-api-backend/src/controllers/userController.js
+++ b/calendar-api-backend/src/controllers/userController.js
@@ -53,47 +53,101 @@ const userInfo_cl = async (req, res) => {
   res.status(200).json(response);
 };
 
-const newClerkUser = async (req, res) => {
-  const secret = process.env.CLERK_WEBHOOK_NEW_USER_CREATED_SECRET;
-  const svixHeaders = {
-    "svix-id": req.headers["svix-id"],
-    "svix-timestamp": req.headers["svix-timestamp"],
-    "svix-signature": req.headers["svix-signature"],
-  };
-  const payload = req.rawBody;
-
-  const wh = new Webhook(secret);
-
-  let msg;
+// Creates the mongo user behind a verified clerk "user created" webhook. Runs after
+// the webhook has already been acked, so its only output is the log line it ends on —
+// every path through here must log exactly one outcome.
+const provisionClerkUser = async ({
+  requestId,
+  firstName,
+  lastName,
+  userEmail,
+  clerkId,
+}) => {
+  let slingId;
   try {
-    msg = wh.verify(payload, svixHeaders);
-    msg = msg.data;
-  } catch (e) {
-    console.error("Verification error:", e);
-    return res.status(401).json({ message: "Unauthorized" });
+    slingId = await utils.getSlingIdByEmail(userEmail);
+    if (!slingId) {
+      console.warn(
+        `[${requestId}]: newClerkUser - no sling user matches ${userEmail}; continuing without a slingId`,
+      );
+    }
+  } catch (err) {
+    // A sling outage must not block the signup — slingId is optional on the model
+    // and can be backfilled later via /user/add-clerk-id-to-all-users.
+    console.error(
+      `[${requestId}]: newClerkUser - sling lookup failed for ${userEmail}: ${err.message}. Continuing without a slingId.`,
+    );
   }
 
-  const { first_name: firstName, last_name: lastName } = msg;
-  const userEmail = msg.email_addresses[0].email_address;
-  const clerkId = msg.id;
-  const userId = msg.id;
-  const slingId = utils.getSlingIdByEmail(userEmail);
-
-  console.log(
-    `[${req.requestId}]: newClerkUser called for user: ${userEmail}, clerkId: ${clerkId}, slingId: ${slingId}`,
-  );
-
-  await userService.createUser({
+  const { created } = await userService.createUser({
     firstName,
     lastName,
     email: userEmail,
     slingId,
     clerkId,
   });
-  // await userService.addPositionsToSyncNewUser(userId);
-  // await userService.addBasicPropertiesToNewUser(userId, userEmail);
+  // await userService.addPositionsToSyncNewUser(clerkId);
+  // await userService.addBasicPropertiesToNewUser(clerkId, userEmail);
 
-  res.json();
+  console.log(
+    created
+      ? `[${requestId}]: newClerkUser - created user ${userEmail} (clerkId: ${clerkId}, slingId: ${slingId ?? "none"})`
+      : `[${requestId}]: newClerkUser - user ${userEmail} already existed (clerkId: ${clerkId}); nothing to do`,
+  );
+};
+
+const newClerkUser = async (req, res) => {
+  const svixHeaders = {
+    "svix-id": req.headers["svix-id"],
+    "svix-timestamp": req.headers["svix-timestamp"],
+    "svix-signature": req.headers["svix-signature"],
+  };
+
+  let msg;
+  try {
+    // Webhook() itself throws on a missing/malformed secret, so it belongs in here too.
+    const wh = new Webhook(process.env.CLERK_WEBHOOK_NEW_USER_CREATED_SECRET);
+    msg = wh.verify(req.rawBody, svixHeaders).data;
+  } catch (e) {
+    console.error(
+      `[${req.requestId}]: newClerkUser - webhook verification failed: ${e.message}`,
+    );
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  const { first_name: firstName, last_name: lastName } = msg;
+  const userEmail = msg.email_addresses?.[0]?.email_address;
+  const clerkId = msg.id;
+
+  if (!userEmail) {
+    console.error(
+      `[${req.requestId}]: newClerkUser - payload for clerkId ${clerkId} has no email address; ignoring`,
+    );
+    return res.status(200).json({ message: "ignored: no email address" });
+  }
+
+  // Ack before provisioning: svix gives the endpoint only a few seconds, and the sling
+  // lookup below is a network round trip. The outcome is logged, never returned.
+  console.log(
+    `[${req.requestId}]: newClerkUser - accepted webhook for ${userEmail} (clerkId: ${clerkId}); provisioning`,
+  );
+  res.status(200).json({ message: "accepted" });
+
+  try {
+    await provisionClerkUser({
+      requestId: req.requestId,
+      firstName,
+      lastName,
+      userEmail,
+      clerkId,
+    });
+  } catch (err) {
+    // Nothing to return to clerk at this point — the log is the only signal, so make it loud.
+    console.error(
+      `[${req.requestId}]: newClerkUser - FAILED to provision ${userEmail} (clerkId: ${clerkId}) after acking the webhook: ${err.message}`,
+      err,
+    );
+  }
 };
 
 const getAllUsers_cl = async (_req, res) => {

--- a/calendar-api-backend/src/services/userService.js
+++ b/calendar-api-backend/src/services/userService.js
@@ -3,6 +3,8 @@ import { User } from "../models/UserModel.js";
 import { initialPositions } from "../database/seeds/initialPositions.js";
 import redisClient from "../database/redisClient.js";
 
+// Returns { user, created } so callers can tell an actual insert apart from a
+// no-op on an already-existing user (the clerk webhook logs which one happened).
 const createUser = async (userData) => {
   // const { firstName, lastName, email, password } = userData;
   const { firstName, lastName, email, slingId, clerkId } = userData;
@@ -10,7 +12,7 @@ const createUser = async (userData) => {
   let user = await User.findOne({ email });
 
   if (user) {
-    return user;
+    return { user, created: false };
   }
 
   user = new User({
@@ -25,7 +27,7 @@ const createUser = async (userData) => {
   // user.password = await bcrypt.hash(password, salt);
 
   await user.save();
-  return user;
+  return { user, created: true };
 };
 
 const findUserByEmail = async (email) => {

--- a/calendar-api-backend/src/utils/utils.js
+++ b/calendar-api-backend/src/utils/utils.js
@@ -38,8 +38,9 @@ const shiftToEvent = (shift, colorId) => {
 
 const getSlingIdByEmail = async (email) => {
   const slingService = new SlingService();
-  await slingService.init();
-  const slingUsers = slingService.users;
+  // Only the users endpoint is needed here — it authenticates off SLING_AUTHORIZATION
+  // on its own, so there's no reason to pay for a full init() (session + positions).
+  const slingUsers = await slingService.getAllUsers();
 
   if (!slingUsers) {
     console.error(
@@ -48,8 +49,9 @@ const getSlingIdByEmail = async (email) => {
     return undefined;
   }
 
-  const user = slingUsers.find((user) => user.email === email);
-  return user ? user.slingId : undefined;
+  // getAllUsers() returns an object keyed by sling user id, not an array.
+  const user = Object.values(slingUsers).find((user) => user.email === email);
+  return user ? String(user.id) : undefined;
 };
 
 export default {


### PR DESCRIPTION
## The bug

The Clerk "user created" webhook pointing at `POST /user/clerk/new` has a 100% failure rate, every delivery reporting **"request timed out"**. No agendo user has been provisioned from a signup since it broke.

The endpoint itself is healthy — an unsigned POST to production returns `401` in under a second, so signature verification works and the hang is downstream of it.

`newClerkUser` called the `async` `utils.getSlingIdByEmail` **without awaiting it**:

```js
const slingId = utils.getSlingIdByEmail(userEmail);   // ← a Promise, not a string
```

That Promise went straight into `createUser` and onto the `String` slingId field. Mongoose rejects it:

```
User validation failed: slingId: Cast to string failed for value "Promise { '123' }" (type Promise) at path "slingId"
```

`newClerkUser` is an `async` Express 4 handler with no `try/catch`, and app.js has no error-handling middleware — so Express silently drops the rejected promise. `res.json()` is never reached, nothing is written to the socket, and svix waits until it gives up.

`getSlingIdByEmail` was independently broken and would have thrown even with the `await`: it called `.find()` on the **object keyed by user id** that `getAllUsers()` returns (it's consumed as `this.users[userId]` elsewhere), and read a `slingId` property that only exists on the legacy static list in `utils/slingUsers.js` — the sling API returns `id`. The map shape landed in `6343a22` (Sep 2024); the missing `await` in `eb43ef8` (May 2025).

## The fix

- `await` the sling lookup, and fix `getSlingIdByEmail` to walk `Object.values()` and return `String(user.id)`.
- Drop `init()` there in favour of a direct `getAllUsers()` call — that endpoint authenticates off `SLING_AUTHORIZATION` on its own, so the session + positions round trips were pure waste.
- Move `new Webhook(secret)` **inside** the try. It was outside, so a missing or rotated secret would have thrown into the same silent-hang path instead of returning 401.
- Ack the webhook with `200 {"message":"accepted"}` right after verification, then provision — svix's timeout is short and the sling lookup is a network round trip.
- Wrap provisioning in `try/catch`. The response is already sent by then, so the log is the only signal — every path logs exactly one outcome:

| Path | Log |
|---|---|
| accepted | `accepted webhook for <email> (clerkId: …); provisioning` |
| created | `created user <email> (clerkId: …, slingId: …)` |
| already existed | `user <email> already existed (clerkId: …); nothing to do` |
| no sling match | `no sling user matches <email>; continuing without a slingId` (warn) |
| sling down | `sling lookup failed for <email>: <err>. Continuing without a slingId.` |
| provisioning threw | `FAILED to provision <email> … after acking the webhook: <err>` + stack |
| bad signature | `webhook verification failed: <err>` → 401 |
| no email in payload | `payload for clerkId … has no email address; ignoring` → 200 |

- A sling outage no longer blocks signup — `slingId` is optional on the model and backfillable via `/user/add-clerk-id-to-all-users`.
- `createUser` returns `{ user, created }` so the log can tell an insert from a no-op. Single caller, updated.

## Verification

Ran the real handler directly against the `dev-users` collection with genuinely svix-signed payloads (temp docs removed in a `finally`; cleanup confirmed):

```
=== A. getSlingIdByEmail against a real sling user ===
  -> "15645762" (type: string )        ← previously threw ".find is not a function"

=== B. new user ===  200 accepted, doc created, skills:1 positionsToSync:6
=== C. replay ===    200 accepted, "already existed", still 1 doc
=== D. bad signature ===  401 Unauthorized
=== E. no email ===       200 ignored
```

And the exact case that used to CastError — a new user whose email *does* match a sling user:

```
created user <email> (clerkId: …, slingId: 9242641)
mongo doc slingId: "9242641" (type: string ) matches sling id: true
```

`eslint` on the touched files is clean apart from one pre-existing error, `'userEmail' is not defined` in the legacy unrouted `userInfo` handler — untouched here.

## Not in scope

Every other async handler in this backend has the same Express 4 hazard: a throw means no response rather than a 500. A single error-handling middleware plus `express-async-errors` would close that class off, for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
