### PR TITLE
fix: enforce admin-only on shift, skill and location mutations

### DIFF
--- a/calendar-api-backend/src/controllers/shiftController.js
+++ b/calendar-api-backend/src/controllers/shiftController.js
@@ -6,7 +6,6 @@ import { mergeShiftsFromSling } from "../utils/mergeShiftsFromSling.js";
 import gCalendarService from "../services/gCalendarService.js";
 import positionService from "../services/positionService.js";
 import userService from "../services/userService.js";
-import { userIsAdmin } from "../utils/userIsAdmin.js";
 import isISODate from "../utils/isISODate.js";
 
 function validateShift(shift) {
@@ -434,12 +433,13 @@ async function duplicateShiftsFromDay(req, res) {
     mode = "merge",
     excludePositionIds = [],
   } = req.body;
+  // Stamped onto every duplicated shift as `createdBy` further down.
   const { userId } = req.auth;
 
-  if (!userId || !(await userIsAdmin(userId))) {
-    return res.status(403).json({ message: "Unauthorized" });
-  }
-
+  // The admin check lives on the route (`adminOnly`) like every other shift mutation.
+  // It used to be done here via `utils/userIsAdmin`, which read Clerk
+  // `publicMetadata.type` — a field agendo stopped writing once the profile JSON
+  // outgrew Clerk's metadata size limit, so it denied genuine admins.
   const targets =
     Array.isArray(targetDates) && targetDates.length
       ? targetDates

--- a/calendar-api-backend/src/jiraBacklog/jiraBacklogRouter.js
+++ b/calendar-api-backend/src/jiraBacklog/jiraBacklogRouter.js
@@ -14,7 +14,7 @@ const jiraBacklogRouter = express.Router();
 
 // Admin-only throughout: the Jira Backlog + Tasks pages are admin-only (enforced on the
 // client by AdminRoute), so these endpoints are gated to match — the data isn't readable
-// by a non-admin hitting the API directly. adminOnly is bypassed in development.
+// by a non-admin hitting the API directly.
 jiraBacklogRouter.get("/config", adminOnly, jiraBacklogController.getConfig);
 jiraBacklogRouter.get("/issues", adminOnly, jiraBacklogController.listIssues);
 

--- a/calendar-api-backend/src/middlewares/adminOnly.js
+++ b/calendar-api-backend/src/middlewares/adminOnly.js
@@ -3,18 +3,38 @@ import userService from "../services/userService.js";
 import dotenv from "dotenv";
 dotenv.config();
 
+/**
+ * The single authorization gate in agendo: is this caller an admin?
+ *
+ * Authority is Mongo `user.type`. The other check that used to exist,
+ * `utils/userIsAdmin`, read Clerk `publicMetadata.type` — a field agendo stopped
+ * writing once the user profile JSON outgrew Clerk's metadata size limit — so it
+ * returned false for genuine admins. It has been removed; do not reintroduce a
+ * publicMetadata read for authorization.
+ *
+ * This used to `next()` unconditionally when `NODE_ENV === "development"`, which meant
+ * no gated route was ever really exercised locally and every role bug stayed invisible
+ * until production. The bypass is gone: local dev now behaves exactly like production.
+ * If you get a 403 locally, your Clerk user needs `type: "admin"` in the `dev-users`
+ * collection (collections are environment-split — see models/userModel.js).
+ */
 export default async function adminOnly(req, res, next) {
   const { userId } = getAuth(req);
   if (!userId) {
     return res.status(401).json({ error: "Unauthorized" });
   }
+
   const user = await userService.findUserByClerkId(userId);
-  if (process.env.NODE_ENV === "development") {
-    next();
-    return;
-  }
-  if (!user || (user && user.type !== "admin")) {
+
+  if (!user || user.type !== "admin") {
+    // Logged because a 403 here is otherwise indistinguishable from a bug: the two
+    // causes (no Mongo record for this Clerk id vs. a non-admin) need different fixes.
+    console.warn(
+      `[${req.requestId}] - adminOnly denied ${req.method} ${req.originalUrl} for clerkId ${userId}: ` +
+        (user ? `type is "${user.type}"` : "no matching user in Mongo"),
+    );
     return res.status(403).json({ error: "Forbidden" });
   }
+
   next();
 }

--- a/calendar-api-backend/src/routers/coverageMeterRouter.js
+++ b/calendar-api-backend/src/routers/coverageMeterRouter.js
@@ -6,7 +6,7 @@ const coverageMeterRouter = express.Router();
 
 // Admin-only throughout, reads included: coverage targets are a management tool and
 // the schedule page only renders coverage rows for admins, so the data isn't readable
-// by a normal user hitting the API directly. adminOnly is bypassed in development.
+// by a normal user hitting the API directly.
 //
 // The whole list is written at once (PUT /) rather than per-item CRUD, because the
 // settings card batches every edit behind a single "Save changes" button.

--- a/calendar-api-backend/src/routers/locationRouter.js
+++ b/calendar-api-backend/src/routers/locationRouter.js
@@ -1,7 +1,13 @@
 import express from "express";
 import locationController from "../controllers/locationController.js";
+import adminOnly from "../middlewares/adminOnly.js";
 
 const locationRouter = express.Router();
+
+// Locations are org-wide config, edited only from Settings › Manage locations, which
+// renders behind `type === "admin"` (Settings.tsx). Mutations are therefore admin-only.
+// Reads stay open to any authenticated user: `GET /all` feeds that same page and is
+// harmless roster context, and gating it would risk breaking a read path for no gain.
 
 /**
  * @openapi
@@ -60,7 +66,7 @@ locationRouter.get("/all", locationController.getAllLocations);
  *                 [otherProps]:
  *                   type: string
  */
-locationRouter.post("/new", locationController.createLocation);
+locationRouter.post("/new", adminOnly, locationController.createLocation);
 
 /**
  * @openapi
@@ -135,7 +141,7 @@ locationRouter.get("/:id", locationController.getLocationById);
  *       404:
  *         description: Location not found
  */
-locationRouter.put("/:id", locationController.updateLocation);
+locationRouter.put("/:id", adminOnly, locationController.updateLocation);
 
 /**
  * @openapi
@@ -156,7 +162,7 @@ locationRouter.put("/:id", locationController.updateLocation);
  *       404:
  *         description: Location not found
  */
-locationRouter.delete("/:id", locationController.deleteLocation);
+locationRouter.delete("/:id", adminOnly, locationController.deleteLocation);
 
 /**
  * @openapi

--- a/calendar-api-backend/src/routers/shiftRouter.js
+++ b/calendar-api-backend/src/routers/shiftRouter.js
@@ -1,23 +1,38 @@
 import express from "express";
 import shiftController from "../controllers/shiftController.js";
+import adminOnly from "../middlewares/adminOnly.js";
 
 const shiftRouter = express.Router();
 
-shiftRouter.post("/new", shiftController.createShift);
+// Every shift mutation is admin-only. The UI has always enforced this (EmptySlot,
+// Shift, CreateShiftBtn, DuplicateShifts and ToggleBulkSelector all no-op or render
+// nothing for a non-admin), but the server did not — so a normal authenticated user
+// could create, rewrite or delete any shift by calling the API directly. `createShift`
+// is the sharpest case: it takes an arbitrary `userIds` array and writes Google
+// Calendar events into those employees' real calendars.
+//
+// Reads stay open to any authenticated user: the schedule page shows the whole
+// roster's day to everyone.
+
+shiftRouter.post("/new", adminOnly, shiftController.createShift);
 
 shiftRouter.get("/range", shiftController.findShiftsByRange);
 
 shiftRouter.get("/", shiftController.getShift);
 
-shiftRouter.put("/", shiftController.updateShift);
+shiftRouter.put("/", adminOnly, shiftController.updateShift);
 
-shiftRouter.post("/delete", shiftController.deleteShift);
+shiftRouter.post("/delete", adminOnly, shiftController.deleteShift);
 
 shiftRouter.get(
   "/range/with-sling",
   shiftController.findShiftsByRangeWithSling
 );
 
-shiftRouter.post("/duplicate-shifts", shiftController.duplicateShiftsFromDay);
+shiftRouter.post(
+  "/duplicate-shifts",
+  adminOnly,
+  shiftController.duplicateShiftsFromDay
+);
 
 export default shiftRouter;

--- a/calendar-api-backend/src/routers/skillRouter.js
+++ b/calendar-api-backend/src/routers/skillRouter.js
@@ -1,7 +1,13 @@
 import express from "express";
 import skillController from "../controllers/skillController.js";
+import adminOnly from "../middlewares/adminOnly.js";
 
 const skillRouter = express.Router();
+
+// Skills are a global taxonomy assigned to users (see `skills` on the User model), not
+// per-user data — renaming or deleting one reaches every user holding it. No frontend
+// code calls these mutations at all today (the only frontend reference to skills is the
+// `skillTypes.ts` type), so they are admin-only config endpoints. Reads stay open.
 
 /**
  * @openapi
@@ -134,7 +140,7 @@ skillRouter.get("/:skillId", skillController.getSkillById);
  *                 message:
  *                   type: string
  */
-skillRouter.post("/", skillController.createSkill);
+skillRouter.post("/", adminOnly, skillController.createSkill);
 
 /**
  * @openapi
@@ -203,7 +209,7 @@ skillRouter.post("/", skillController.createSkill);
  *                 message:
  *                   type: string
  */
-skillRouter.put("/:skillId", skillController.updateSkill);
+skillRouter.put("/:skillId", adminOnly, skillController.updateSkill);
 
 /**
  * @openapi
@@ -248,6 +254,6 @@ skillRouter.put("/:skillId", skillController.updateSkill);
  *                 message:
  *                   type: string
  */
-skillRouter.delete("/:skillId", skillController.deleteSkill);
+skillRouter.delete("/:skillId", adminOnly, skillController.deleteSkill);
 
 export default skillRouter;

--- a/calendar-api-backend/src/utils/userIsAdmin.js
+++ b/calendar-api-backend/src/utils/userIsAdmin.js
@@ -1,6 +1,0 @@
-import userService from "../services/userService.js";
-
-export async function userIsAdmin(userId) {
-  const user = await userService.findUser_cl(userId);
-  return user.publicMetadata.type === "admin";
-}


### PR DESCRIPTION
## The gap

Several mutation endpoints were mounted behind `requireAuth()` only — authentication with no authorization — even though the frontend has always treated them as admin-only. Any authenticated user could call them directly:

| Endpoint | Risk |
|---|---|
| `POST /shift/new` | Accepts an arbitrary `userIds` array and writes Google Calendar events into those employees' **real calendars** |
| `PUT /shift` | Takes `shiftId` from the query string, no ownership or role check — rewrite any shift |
| `POST /shift/delete` | Same — delete any shift by id |
| `skillRouter` POST/PUT/DELETE | Global taxonomy, open to any user |
| `locationRouter` POST/PUT/DELETE | Org-wide config, open to any user |

All are now gated with the existing `adminOnly` middleware. **Reads stay open** — the schedule page shows the whole roster's day to everyone.

## Why admin-only, not per-user ownership

Normal users do not create, edit or delete shifts anywhere in the product, so this is pure hardening with no product change. Confirmed every frontend caller is already admin-gated:

- `EmptySlot.tsx:125` — renders an inert `div` for non-admins
- `Shift.tsx:85,209,215` — click, drag and the edit dialog all no-op
- `CreateShiftBtn.tsx:22`, `DuplicateShifts.tsx:20` — `return null`
- `ToggleBulkSelector.tsx:20` — `return null`, so `BulkDeleteBtn` never mounts
- Skills have **no frontend caller at all**; locations are edited only from Settings › Manage locations, which renders behind `type === "admin"`

Returning 403 where the UI never sent the request should be invisible to users.

## Two disagreeing admin checks, resolved

The codebase had two: `middlewares/adminOnly.js` (Mongo `user.type`) and `utils/userIsAdmin.js` (Clerk `publicMetadata.type`). Verified against live data:

| | Mongo `user.type` | Clerk `publicMetadata.type` |
|---|---|---|
| `joao.coelho@duda.co` | `admin` | **unset** (`{}`) |
| `rafael.schmitz@duda.co` | `admin` | `admin` |

`userIsAdmin` returns **false for a genuine admin** — agendo stopped writing `publicMetadata` once the profile JSON outgrew Clerk's metadata size limit. Its only caller was `duplicateShiftsFromDay`, so **`POST /shift/duplicate-shifts` was not merely mis-gated — it was denying real admins in production.** Moving it to `adminOnly` fixes a live bug. `utils/userIsAdmin.js` is deleted.

This matches the boundary proposed in the (still unlanded) `docs/clerk-mongo-user-cleanup-brief.md`, which scopes these authorization gaps to a separate pass — this one.

## Dev bypass removed — please ack

`adminOnly` used to `next()` unconditionally when `NODE_ENV === "development"`. That meant no gated route was ever really exercised locally, which is why this whole class of bug stayed invisible until production. It's gone; local dev now behaves like production.

Safe today because **both `dev-users` records are already `type: "admin"`**, so local access is unaffected. This is the most reversible decision in the PR if it bites anyone. A 403 locally now means your Clerk user needs `type: "admin"` in `dev-users`. Also added a `console.warn` distinguishing "no Mongo record for this Clerk id" from "not an admin" — the two 403s need different fixes.

## Verification

No test suite, so two passes:

**1. Router-stack introspection** — `adminOnly` present on all six routes:
```
GATED   POST   /new              adminOnly -> createShift
GATED   PUT    /                 adminOnly -> updateShift
GATED   POST   /delete           adminOnly -> deleteShift
GATED   POST   /duplicate-shifts adminOnly -> duplicateShiftsFromDay
```

**2. Runtime, over real Mongo with `NODE_ENV=production`** (no bypass, real `users` collection):
```
PASS  admin user            expected 200, got 200
PASS  normal user           expected 403, got 403
PASS  clerkId not in Mongo  expected 403, got 403
PASS  unauthenticated       expected 401, got 401
```

ESLint clean on all touched files.

## Deliberately left alone

`PUT /position/sync` and `PUT /position/default-color` are ungated and **correctly so** — they derive the user from `req.auth.userId` and accept no user id from the request, making them genuine self-service. Worth preserving that property.

## Why now

Prerequisite for the planned MCP server (remote HTTP, Clerk OAuth via `@clerk/mcp-tools`). An MCP tool layer would hand an LLM the ability to call these endpoints on behalf of a normal user, so the missing server-side checks need closing before that ships.

---

Incidental finding for whoever picks up the Clerk/Mongo cleanup: `req.auth` in `@clerk/express` 1.7.x is a Proxy over a function, so `req.auth.userId` works but emits a deprecation warning — the ~4 controllers destructuring it will need `req.auth()` eventually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
